### PR TITLE
the cp commands are required for team members to develop new shortcodes

### DIFF
--- a/scripts/local_copy.sh
+++ b/scripts/local_copy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+cp ../UserRepo/layouts/shortcodes/* layouts/shortcodes
+cp ../UserRepo/layouts/partials/* layouts/partials
+
 case "$1" in
   "server")
     cmd="hugo server --bind=0.0.0.0"


### PR DESCRIPTION
…es in their repo.  they throw an error when no shortcodes are present, but it's a non-issue