### PR TITLE
fix(checkin): remove invalid pattern attr that crashes Chrome v-flag regex

### DIFF
--- a/layouts/partials/analytics_checkin.html
+++ b/layouts/partials/analytics_checkin.html
@@ -125,7 +125,7 @@ container.innerHTML = `
   <form id="provision-lab" class="checkin-card" action="${ANALYTICS_BASE}/checkin" method="POST">
     <div class="checkin-title">Welcome!</div>
     <div class="checkin-sub">Please check-in for this workshop to proceed (REQUIRED)</div>
-    <div class="checkin-row"><label for="email">Email</label><input class="checkin-input" type="email" required id="email" name="EMail" autocomplete="email" pattern="^[A-Za-z0-9\._\%\+\-]+@[A-Za-z0-9\.\-]+\.[A-Za-z]{2,}$" title="Enter a valid email (e.g., name+csetester@example.com)" /></div>
+    <div class="checkin-row"><label for="email">Email</label><input class="checkin-input" type="email" required id="email" name="EMail" autocomplete="email" /></div>
     <div class="checkin-row"><label for="customer">Customer</label><input class="checkin-input" type="text" id="customer" name="Customer" /></div>
     <input type="hidden" id="marketing_code" name="Event" value="${MARKETING_CODE}" />
     <input type="hidden" id="workshop_id" name="workshopID" value="${WORKSHOP_ID}" />


### PR DESCRIPTION
## Summary

- Removes the redundant `pattern` attribute from the email `<input>` in `analytics_checkin.html`
- The attribute used backslash-escapes (`\._\%\+\-`) inside a JS template literal; JS string processing strips those backslashes, leaving `[._%+-]` in the rendered HTML
- Chrome 130+ uses the `v` flag for HTML `pattern` validation and rejects that character class (`+-` looks like an ambiguous range), throwing an Uncaught SyntaxError that prevents form submission entirely
- `type="email"` and the existing `emailRegex` on line 151 already validate the address — the `pattern` was redundant

## Test plan

- [ ] Confirm no console errors on check-in form load in Chrome 130+
- [ ] Verify email validation still works (invalid emails blocked by `type="email"` + JS `emailRegex`)
- [ ] Confirm successful check-in POST reaches `analyticsBaseUrl/checkin` for a configured workshop

🤖 Generated with [Claude Code](https://claude.com/claude-code)