### PR TITLE
fix(checkin): apply prod URL fallback to silent_cross_site_checkin analyticsBase

### DIFF
--- a/layouts/partials/silent_cross_site_checkin.html
+++ b/layouts/partials/silent_cross_site_checkin.html
@@ -1,4 +1,4 @@
-{{- $analyticsBase := .Site.Params.analyticsBaseUrl | default "" -}}
+{{- $analyticsBase := .Site.Params.analyticsBaseUrl | default "https://tecanalytics.forticloudcse.com" -}}
 {{- $quizUrl := .Site.Params.quizUrl | default "" -}}
 <script>
 (function(){


### PR DESCRIPTION
## Summary

- `silent_cross_site_checkin.html` defaulted `analyticsBaseUrl` to `""` while `analytics_checkin.html` correctly fell back to `"https://tecanalytics.forticloudcse.com"`.
- When CI builds the no-URL variant, the silent checkin partial rendered `ANALYTICS_BASE = ""`, failing assertion A8 (`ANALYTICS_BASE is not empty`).
- One-line fix aligns the fallback in both partials.

## Test plan

- [x] CI `assert-html` A8 passes on `public/` (URL configured)
- [x] CI `assert-html` A8 passes on `public-no-url/` (no URL configured — uses prod fallback)
- [x] All other A1–A11 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)