### PR TITLE
fix(theme): default videoHeaderSrc for CloudCSEMovie when not set in repoConfig

### DIFF
--- a/scripts/templates/hugo.jinja
+++ b/scripts/templates/hugo.jinja
@@ -110,10 +110,13 @@ enableEmoji = true
   {% if analyticsBaseUrl is defined and analyticsBaseUrl != "" %}
   analyticsBaseUrl = "{{analyticsBaseUrl}}"
   {% endif %}
-  {% if videoHeaderSrc is defined and videoHeaderSrc != "" %}
-  videoHeaderSrc = "{{videoHeaderSrc}}"
+  {% set effectiveVideoSrc = videoHeaderSrc if (videoHeaderSrc is defined and videoHeaderSrc != "") else ("/videos/CloudsAnimated.mp4" if themeVariant == "CloudCSEMovie" else "") %}
+  {% if effectiveVideoSrc != "" %}
+  videoHeaderSrc = "{{effectiveVideoSrc}}"
   {% if videoHeaderInterval is defined and videoHeaderInterval != "" %}
   videoHeaderInterval = {{videoHeaderInterval}}
+  {% else %}
+  videoHeaderInterval = 60
   {% endif %}
   {% endif %}
 


### PR DESCRIPTION
## Summary
- Repos using `themeVariant=CloudCSEMovie` without an explicit `videoHeaderSrc` in `repoConfig.json` (e.g. AWS-FGT-301) got a blank sidebar header — the `{{ with .Site.Params.videoHeaderSrc }}` block in `custom-header.html` never fired because the param was never emitted into `hugo.toml`.
- Jinja template now defaults `videoHeaderSrc` to `/videos/CloudsAnimated.mp4` (already bundled in `static/videos/`) when `themeVariant == "CloudCSEMovie"` and no explicit override is provided.
- Also defaults `videoHeaderInterval` to `60` when omitted alongside a video src.
- Repos on other themes are unaffected. Repos that explicitly set `videoHeaderSrc` continue to use their value.

## Test plan
- [ ] CI hugo-build passes on this PR
- [ ] After merge + new Docker image build, verify AWS-FGT-301 sidebar header shows the animated video
- [ ] Verify other theme variants (Workshop, UseCase, etc.) are unaffected — no `videoHeaderSrc` emitted for them without explicit config

🤖 Generated with [Claude Code](https://claude.com/claude-code)