### PR TITLE
feat(layout): move version/revision/last-updated to navbar footer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,20 @@
 
 ## [Unreleased]
 
+### feat(layout): move Version/Revision/Last Updated to navbar footer
+
+Version, Revision, and Last Updated info was previously shown only on the home page content footer alongside the legal copyright block. It is now displayed in the left navbar footer (below the Privacy | Site Terms | About Us links) on every page, giving readers consistent access to version info regardless of which page they are on.
+
+The legal copyright text remains in the home page content footer unchanged.
+
+**Files changed**
+| File | Change |
+|------|--------|
+| `layouts/partials/menu-footer.html` | Added version/revision/last-updated block; changed `#footer` height from fixed `6.25rem` to `auto` |
+| `layouts/partials/copyright.html` | Removed version/revision/last-updated block; copyright text only |
+
+---
+
 ### CloudCSEMovie Theme — MP4 Video Sidebar Header
 
 Added a new Hugo theme variant `CloudCSEMovie` that plays an MP4 video in the sidebar header area in place of a static background image.

--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,18 +1,5 @@
 <div style="font-size: small; color: gray; margin-top: 5rem; padding-top: 1rem; border-top: 1px solid gray;">
-{{- /* Version is baked into this file during Docker image build by replacing the getenv line */ -}}
-{{- $version := os.Getenv "HUGO_VERSION_TAG" -}}
-{{- if not $version -}}
-  {{- if (fileExists "VERSION") -}}
-    {{- $version = (readFile "VERSION" | strings.TrimSpace) -}}
-  {{- end -}}
-{{- end -}}
-{{- if $version }}
-  <div>CloudCSE Version: {{ $version }}</div>
-{{- end }}
-  <div>Revision: {{.Site.Params.version}}</div>
-    <div>Last updated: <span id="last-updated-time-utc">{{ dateFormat "Mon, Jan 2, 2006 15:04:05 MST" now }}</span>
-    </div>
-    <div style="margin-top: 1rem;">Copyright© {{ dateFormat "2006" now }} Fortinet, Inc. All rights reserved. Fortinet®,
+    <div>Copyright© {{ dateFormat "2006" now }} Fortinet, Inc. All rights reserved. Fortinet®,
         FortiGate®, FortiCare®
         and FortiGuard®, and
         certain other marks are registered trademarks of Fortinet, Inc., and other Fortinet names herein may also be

--- a/layouts/partials/menu-footer.html
+++ b/layouts/partials/menu-footer.html
@@ -1,7 +1,7 @@
           <style>
             #footer {
               font-size: .8125rem;
-              height: 6.25rem;
+              height: auto;
               margin-left: auto;
               margin-right: auto;
               padding: 2rem 1rem;
@@ -21,3 +21,18 @@
         href="https://www.fortinet.com/corporate/about-us/about-us" target="_blank" rel="noreferrer noopener">About Us</a>
 
 </left>
+
+{{- /* Version/revision block — baked in at Docker build time */ -}}
+{{- $version := os.Getenv "HUGO_VERSION_TAG" -}}
+{{- if not $version -}}
+  {{- if (fileExists "VERSION") -}}
+    {{- $version = (readFile "VERSION" | strings.TrimSpace) -}}
+  {{- end -}}
+{{- end -}}
+<div style="font-size: .75rem; color: gray; margin-top: .75rem; padding-top: .5rem; border-top: 1px solid gray; text-align: left;">
+{{- if $version }}
+  <div>CloudCSE Version: {{ $version }}</div>
+{{- end }}
+  <div>Revision: {{.Site.Params.version}}</div>
+  <div>Last updated: <span id="last-updated-time-utc">{{ dateFormat "Mon, Jan 2, 2006 15:04:05 MST" now }}</span></div>
+</div>


### PR DESCRIPTION
## Summary
- Moves CloudCSE Version, Revision, and Last Updated from the home-page content footer into the left navbar menu-footer, so version info is visible on every page
- Legal copyright text stays in the home-page footer unchanged
- Fixes `#footer` height from fixed `6.25rem` to `auto` to prevent content clipping

## Files changed
| File | Change |
|------|--------|
| `layouts/partials/menu-footer.html` | Added version/revision/last-updated block; `height: auto` |
| `layouts/partials/copyright.html` | Removed version/revision/last-updated block |
| `RELEASE_NOTES.md` | Documented change |

## Test plan
- [x] Local: `npm run validate:regex` — pass
- [x] Local: `npm run validate:config` — pass
- [x] CI: `hugo-build` — pass
- [x] CI: `lint-and-validate` — pass
- [x] CI: `hugo-build-no-analytics-url` — pass
- [x] CI: `assert-html` — pass
- [x] CI: `Build Fortinet Hugo workshop development images` — pass (dev image pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)