### PR TITLE
fix: logo height/src whitespace, Dockerfile version injection, add A12-A14 tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ RUN apk --no-cache --allow-untrusted --repository http://dl-cdn.alpinelinux.org/
     ln -sf python3 /usr/bin/python && \
     ln -sf /sbin/tini-static /sbin/tini
 
-# Inject version into copyright.html partial
+# Inject version into menu-footer.html partial
 RUN sed -i "s|{{- \\\$version := os.Getenv \"HUGO_VERSION_TAG\" -}}|{{- \\\$version := \"${CENTRALREPO_VERSION}\" -}}|" \
-    /home/CentralRepo/layouts/partials/copyright.html
+    /home/CentralRepo/layouts/partials/menu-footer.html
 
 ENTRYPOINT ["/sbin/tini", "--", "/home/CentralRepo/scripts/local_copy.sh"]
 
@@ -71,8 +71,8 @@ RUN apk --no-cache --allow-untrusted --repository http://dl-cdn.alpinelinux.org/
     ln -sf python3 /usr/bin/python && \
     ln -sf /sbin/tini-static /sbin/tini
 
-# Inject version into copyright.html partial
+# Inject version into menu-footer.html partial
 RUN sed -i "s|{{- \\\$version := os.Getenv \"HUGO_VERSION_TAG\" -}}|{{- \\\$version := \"${CENTRALREPO_VERSION}\" -}}|" \
-    /home/CentralRepo/layouts/partials/copyright.html
+    /home/CentralRepo/layouts/partials/menu-footer.html
 
 ENTRYPOINT ["/sbin/tini", "--", "/home/CentralRepo/scripts/local_copy.sh"]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,39 @@
 
 ## [Unreleased]
 
+### fix(logo): restore height, eliminate whitespace in src attribute
+
+The logo `<img>` was missing its `height="70px"` attribute (removed in a prior commit) causing the logo to render at intrinsic size. The multi-line Go template also injected leading whitespace into the `src` attribute value. Both fixed by collapsing the template conditionals onto one line and restoring the height.
+
+**Files changed**
+| File | Change |
+|------|--------|
+| `layouts/partials/logo.html` | Inline `src` conditionals (no whitespace injection), restore `height="70px"` |
+
+---
+
+### fix(dockerfile): version injection now targets menu-footer.html
+
+The Dockerfile `sed` that bakes `CENTRALREPO_VERSION` into the Hugo templates still targeted `copyright.html` after the version block was moved to `menu-footer.html`. This caused the CloudCSE Version to never appear in the navbar footer in deployed images.
+
+**Files changed**
+| File | Change |
+|------|--------|
+| `Dockerfile` | `sed` target changed from `copyright.html` to `menu-footer.html` (both dev and prod stages) |
+
+---
+
+### test: add A12–A14 assertions to catch logo and version injection regressions
+
+Three new HTML/source assertions added to `test_rendered_html.sh`:
+- **A12**: logo `img src` must not contain leading whitespace (catches multiline template injection)
+- **A13**: Dockerfile must not reference `copyright.html` for version injection
+- **A14**: `menu-footer.html` must contain the `HUGO_VERSION_TAG` pattern (Dockerfile sed target is valid)
+
+**Root cause of why these weren't caught:** The existing test suite only validated rendered HTML for analytics/form/CSS correctness. It had no assertions about the logo `src` attribute format or about the Dockerfile → template alignment. Added tests at both the rendered-HTML layer (A12) and source-file layer (A13, A14) to catch future drift.
+
+---
+
 ### feat(layout): move Version/Revision/Last Updated to navbar footer
 
 Version, Revision, and Last Updated info was previously shown only on the home page content footer alongside the legal copyright block. It is now displayed in the left navbar footer (below the Privacy | Site Terms | About Us links) on every page, giving readers consistent access to version info regardless of which page they are on.

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,18 +1,8 @@
 <a id="logo" href='{{relURL "index.html"}}' title="Fortinet TEC Program">
   <img
     style="vertical-align: middle"
-    src='
-        {{if (eq .Site.Params.themeVariant "Xperts2023") }}
-            {{ relURL "images/xperts-2023-2-lines.svg" }}
-        {{ else if (eq .Site.Params.themeVariant "Xperts2024")}}
-            {{ relURL "images/xperts-2024-2-lines.svg" }}
-        {{ else if (eq .Site.Params.themeVariant "Xperts2025")}}
-            {{ relURL "images/xperts-2025-3-lines.png" }}
-        {{ else if (eq .Site.Params.themeVariant "Workshop")}}
-            {{ relURL "images/white-logo.svg" }}
-        {{ else }}
-            {{ relURL "images/logo.svg" }}
-        {{end}}'
+    src='{{- if (eq .Site.Params.themeVariant "Xperts2023") -}}{{ relURL "images/xperts-2023-2-lines.svg" }}{{- else if (eq .Site.Params.themeVariant "Xperts2024") -}}{{ relURL "images/xperts-2024-2-lines.svg" }}{{- else if (eq .Site.Params.themeVariant "Xperts2025") -}}{{ relURL "images/xperts-2025-3-lines.png" }}{{- else if (eq .Site.Params.themeVariant "Workshop") -}}{{ relURL "images/white-logo.svg" }}{{- else -}}{{ relURL "images/logo.svg" }}{{- end -}}'
+    height="70px"
   />
 
     {{ with .Site.Params.logoBannerText }}

--- a/scripts/test/test_rendered_html.sh
+++ b/scripts/test/test_rendered_html.sh
@@ -80,5 +80,27 @@ if grep -rq 'htmlEscape' "$REPO_ROOT/layouts/"; then
 fi
 pass "A11: no htmlEscape in layout source files"
 
+# A12: Logo img src must not contain leading whitespace or newlines
+# The Go template multiline src='\n...\n' pattern causes broken img in some environments.
+# Catches regressions where the logo template puts whitespace inside the src attribute value.
+if grep -Pzo 'src='"'"'\s*\n' "$PUBLIC_DIR/index.html" > /dev/null 2>&1; then
+  fail "A12: logo img src attribute contains leading whitespace/newlines — clean up logo.html template"
+fi
+pass "A12: logo img src is clean (no leading whitespace)"
+
+# A13: Dockerfile must target menu-footer.html for version injection, not copyright.html
+# Catches the regression where the sed target was left pointing at a file that no longer
+# contains the os.Getenv pattern after moving version display to menu-footer.html.
+if grep -q 'copyright.html' "$REPO_ROOT/Dockerfile" && grep -q 'HUGO_VERSION_TAG' "$REPO_ROOT/Dockerfile"; then
+  fail "A13: Dockerfile sed targets copyright.html for version injection — should target menu-footer.html"
+fi
+pass "A13: Dockerfile version injection targets correct file"
+
+# A14: menu-footer.html must contain the os.Getenv version pattern (Dockerfile sed target is valid)
+if ! grep -q 'os.Getenv "HUGO_VERSION_TAG"' "$REPO_ROOT/layouts/partials/menu-footer.html"; then
+  fail "A14: menu-footer.html missing HUGO_VERSION_TAG pattern — Dockerfile sed will silently fail to inject version"
+fi
+pass "A14: menu-footer.html contains HUGO_VERSION_TAG pattern for Dockerfile version injection"
+
 echo ""
 echo "All assertions passed for: $PUBLIC_DIR"


### PR DESCRIPTION
## Summary
- **Logo fix**: `logo.html` had whitespace injected into the `img src` attribute from multiline Go template conditionals, and was missing `height="70px"` (removed in a prior commit). Collapsed conditionals to one line; restored height.
- **Version injection fix**: Dockerfile `sed` still targeted `copyright.html` after the version block was moved to `menu-footer.html` — CloudCSE Version never appeared in the navbar footer in deployed images. Both dev and prod stages updated to target `menu-footer.html`.
- **New test assertions A12–A14**: catch logo src whitespace, Dockerfile sed target correctness, and menu-footer template pattern presence.

## Why these weren't caught before
The test suite had no assertions about logo `src` formatting or Dockerfile-to-template alignment. Tests validated analytics/form/CSS output but not the logo attribute or the version injection plumbing. The new assertions close both gaps.

## Test plan
- [x] Local: all 14 HTML assertions pass (`bash scripts/test/test_rendered_html.sh public/`)
- [x] Local: `npm run validate:regex` — pass
- [x] Local: `npm run validate:config` — pass
- [x] CI: `hugo-build` — pass
- [x] CI: `lint-and-validate` — pass
- [x] CI: `hugo-build-no-analytics-url` — pass
- [x] CI: `assert-html` (includes new A12–A14) — pass
- [x] CI: `Build Fortinet Hugo workshop development images` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)