### PR TITLE
fix: CORS error on launchdemoform Azure Automation webhook

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased]
 
+### fix(launchdemoform): resolve CORS error on Azure Automation webhook
+
+`fetch()` was rejecting with TypeError and showing a red "Network error" to users on sites like PublicCloud105-FortiFlex. Root cause: Azure Automation webhooks return no `Access-Control-Allow-Origin` header; the POST itself goes through fine but the browser blocks JS from reading the opaque response. Fixed by adding `mode: 'no-cors'` so `fetch` resolves (opaque response) instead of rejecting. Status message updated to "Provisioning request sent."
+
+**Files changed**
+| File | Change |
+|------|--------|
+| `layouts/shortcodes/launchdemoform.html` | Add `mode: 'no-cors'` to fetch call; remove unreachable response-parsing code |
+
+---
+
 ### fix(logo): restore height, eliminate whitespace in src attribute
 
 The logo `<img>` was missing its `height="70px"` attribute (removed in a prior commit) causing the logo to render at intrinsic size. The multi-line Go template also injected leading whitespace into the `src` attribute value. Both fixed by collapsing the template conditionals onto one line and restoring the height.

--- a/layouts/shortcodes/launchdemoform.html
+++ b/layouts/shortcodes/launchdemoform.html
@@ -142,27 +142,16 @@
       });
       if (DEBUG) console.info('launchdemoform: POST', { url: POST_URL, body: body.toString() });
       try {
-        const res = await fetch(POST_URL, {
+        // Azure Automation webhooks don't return CORS headers, so use no-cors mode.
+        // The request is still sent; we just can't read the response (opaque).
+        await fetch(POST_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: body.toString()
+          body: body.toString(),
+          mode: 'no-cors'
         });
-        let text = '';
-        try { text = await res.text(); } catch (e) { text = ''; }
-        let jobId = '';
-        try {
-          const json = text ? JSON.parse(text) : null;
-          if (json) {
-            jobId = json.JobId || json.jobId || (Array.isArray(json.JobIds) && json.JobIds[0]) || '';
-          }
-        } catch (e) { /* ignore non-JSON */ }
-        const accepted = (res.status === 202) && !!jobId;
-        if (DEBUG) console.info('launchdemoform: response', { status: res.status, accepted, jobId, text });
-        if (accepted) {
-          setStatus('Provisioning request accepted. Please wait for your lab to be prepared.', 'ok');
-        } else {
-          setStatus('Provisioning failed: ' + (text || ('HTTP ' + res.status)), 'err');
-        }
+        if (DEBUG) console.info('launchdemoform: request sent (no-cors, response opaque)');
+        setStatus('Provisioning request sent. Please wait for your lab to be prepared.', 'ok');
       } catch (err) {
         if (DEBUG) console.error('launchdemoform: network error', err);
         setStatus('Network error while provisioning: ' + (err && err.message ? err.message : err), 'err');


### PR DESCRIPTION
## Summary
- Azure Automation webhooks don't return `Access-Control-Allow-Origin` headers
- The async `fetch()` rewrite (Aug 2025) surfaced this as a visible red "Network error" on sites like PublicCloud105-FortiFlex — provisioning was actually succeeding all along
- Fix: add `mode: 'no-cors'` so fetch resolves with an opaque response instead of rejecting; removed the now-unreachable response-parsing code

## Test plan
- [ ] CI passed on `prreviewJune23` (both CI and dev image build workflows green)
- [ ] Verify provisioning button on PublicCloud105-FortiFlex no longer shows CORS error after prod image rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)