### PR TITLE
fix: CORS fix for launchdemoform + logo/version/Dockerfile/test improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased]
 
+### fix(launchdemoform): resolve CORS error on Azure Automation webhook
+
+`fetch()` was rejecting with TypeError and showing a red "Network error" to users on sites like PublicCloud105-FortiFlex. Root cause: Azure Automation webhooks return no `Access-Control-Allow-Origin` header; the POST itself goes through fine but the browser blocks JS from reading the opaque response. Fixed by adding `mode: 'no-cors'` so `fetch` resolves (opaque response) instead of rejecting. Status message updated to "Provisioning request sent."
+
+**Files changed**
+| File | Change |
+|------|--------|
+| `layouts/shortcodes/launchdemoform.html` | Add `mode: 'no-cors'` to fetch call; remove unreachable response-parsing code |
+
+---
+
 ### fix(logo): restore height, eliminate whitespace in src attribute
 
 The logo `<img>` was missing its `height="70px"` attribute (removed in a prior commit) causing the logo to render at intrinsic size. The multi-line Go template also injected leading whitespace into the `src` attribute value. Both fixed by collapsing the template conditionals onto one line and restoring the height.

--- a/layouts/shortcodes/launchdemoform.html
+++ b/layouts/shortcodes/launchdemoform.html
@@ -142,27 +142,16 @@
       });
       if (DEBUG) console.info('launchdemoform: POST', { url: POST_URL, body: body.toString() });
       try {
-        const res = await fetch(POST_URL, {
+        // Azure Automation webhooks don't return CORS headers, so use no-cors mode.
+        // The request is still sent; we just can't read the response (opaque).
+        await fetch(POST_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: body.toString()
+          body: body.toString(),
+          mode: 'no-cors'
         });
-        let text = '';
-        try { text = await res.text(); } catch (e) { text = ''; }
-        let jobId = '';
-        try {
-          const json = text ? JSON.parse(text) : null;
-          if (json) {
-            jobId = json.JobId || json.jobId || (Array.isArray(json.JobIds) && json.JobIds[0]) || '';
-          }
-        } catch (e) { /* ignore non-JSON */ }
-        const accepted = (res.status === 202) && !!jobId;
-        if (DEBUG) console.info('launchdemoform: response', { status: res.status, accepted, jobId, text });
-        if (accepted) {
-          setStatus('Provisioning request accepted. Please wait for your lab to be prepared.', 'ok');
-        } else {
-          setStatus('Provisioning failed: ' + (text || ('HTTP ' + res.status)), 'err');
-        }
+        if (DEBUG) console.info('launchdemoform: request sent (no-cors, response opaque)');
+        setStatus('Provisioning request sent. Please wait for your lab to be prepared.', 'ok');
       } catch (err) {
         if (DEBUG) console.error('launchdemoform: network error', err);
         setStatus('Network error while provisioning: ' + (err && err.message ? err.message : err), 'err');


### PR DESCRIPTION
## Summary
- **fix:** Use `mode: no-cors` for Azure Automation webhook fetch — resolves "NetworkError when attempting to fetch resource" seen in K8s-101-workshop and any other workshop using `launchdemoform`
- **fix:** Logo height/src whitespace, Dockerfile version injection
- **feat:** Move version/revision/last-updated to navbar footer
- **ci:** Skip build jobs on docs-only PRs
- **test:** Add A12–A14 test assertions

## Root Cause
Azure Automation webhooks return no CORS headers. The old fetch tried to read the response body, which browsers block for cross-origin requests — triggering a NetworkError client-side. The request was always succeeding server-side; only the response read failed. Fix: `mode: 'no-cors'` so the browser sends the POST and treats the response as opaque (unreadable) rather than rejecting it.

## Test plan
- [ ] CI passes on this PR
- [ ] Prod Docker image builds on merge to main
- [ ] Rebuild K8s-101-workshop against new prod image and verify provisioning succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)