### PR TITLE
ci(image): pin the Hugo base image, skip rebuilds on docs-only pushes

### DIFF
--- a/.github/workflows/image-build-push-dev.yaml
+++ b/.github/workflows/image-build-push-dev.yaml
@@ -4,6 +4,15 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["prreviewJune23"]
+    # Same reasoning as image-build-push-prod.yaml — see the comment there before
+    # adding anything to this list.
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'review/**'
+      - 'LICENSE'
+      - 'LICENSE-SAMPLECODE'
+      - 'LICENSE-SUMMARY'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/image-build-push-prod.yaml
+++ b/.github/workflows/image-build-push-prod.yaml
@@ -4,6 +4,19 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+    # A push that touches only these paths changes nothing inside the image, and
+    # rebuilding republishes `fortinet-hugo:latest` to all 65 workshop repos for
+    # no reason. Keep this list to paths that are provably not baked in: root-level
+    # docs, the docs/ and review/ trees, and the licences. Anything under scripts/,
+    # layouts/, assets/, i18n/, static/, archetypes/, themes/ or the Dockerfile
+    # itself DOES reach the image — never add those here.
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'review/**'
+      - 'LICENSE'
+      - 'LICENSE-SAMPLECODE'
+      - 'LICENSE-SUMMARY'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,13 @@ ARG LOCAL=false
 # Global ARG must be declared before first FROM to be usable in FROM instructions
 ARG LOCAL=false
 
-# Base Hugo image (uses Alpine 3.21)
-FROM hugomods/hugo:std as base
+# Base Hugo image (uses Alpine 3.21). PINNED ON PURPOSE — do not revert to the
+# floating `:std` tag. Every push to main republishes `fortinet-hugo:latest`, and
+# all 65 workshop repos build against that tag, so a floating base silently hands
+# every repo whatever Hugo minor upstream shipped that week. 0.165.0 is what
+# production already runs, so this pin is behaviourally a no-op today.
+# To bump: change the tag here, in its own PR, and say which Hugo version it moves to.
+FROM hugomods/hugo:std-0.165.0 as base
 
 ############################
 # DEV STAGE — source variants

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,23 @@
 
 ## [Unreleased]
 
+### ci(image): pin the Hugo base image and stop rebuilding on docs-only pushes
+
+Two independent ways a CentralRepo merge could hand all 65 workshop repos an unintended change are now closed.
+
+`Dockerfile` pinned `hugomods/hugo:std` → `hugomods/hugo:std-0.165.0`. The floating tag meant the Hugo version inside `fortinet-hugo:latest` was whatever upstream had published most recently at build time, decided by *when* someone merged rather than by any decision in this repo — observed live on 2026-08-19, when a merge moved the published image from Hugo 0.164.0 to 0.165.0 with nothing in the diff asking for it. 0.165.0 is what production already runs, so the pin changes no behaviour today; it only makes the next Hugo bump an explicit, reviewable commit. Pinning the base also pins Alpine, so the `apk add python3 py3-pip tini-static` layer stops drifting too.
+
+`image-build-push-prod.yaml` and `image-build-push-dev.yaml` gained matching `paths-ignore` lists. Neither had one, so a README- or docs-only merge rebuilt and republished `latest` to every consumer. The list covers only paths that are provably not baked into the image — root-level `*.md`, `docs/**`, `review/**` and the three licence files. Everything under `scripts/`, `layouts/`, `assets/`, `i18n/`, `static/`, `archetypes/`, `themes/` and the `Dockerfile` itself does reach the image and is deliberately absent from the list.
+
+Known consequence, accepted: `versioning.yml` still runs on every push to `main` and is intentionally left without `paths-ignore`, so a docs-only push still cuts a `vYY.Q.<letter>` tag and GitHub release. Image version letters can therefore skip — a tag can exist with no image built for it. Tagging a docs release is defensible and unifying the two is a separate decision.
+
+**Files changed**
+| File | Change |
+|------|--------|
+| `Dockerfile` | Pin base image to `hugomods/hugo:std-0.165.0`, with a comment on why and how to bump |
+| `.github/workflows/image-build-push-prod.yaml` | Add `paths-ignore` to the `push` trigger |
+| `.github/workflows/image-build-push-dev.yaml` | Same `paths-ignore` |
+
 ### feat(shortcodes): pathtabs / pathtab with locked-path banner, upstreamed from ai-101
 
 `pathtabs` / `pathtab` render a deployment-path tab group whose selection is remembered site-wide, so a reader picks Docker vs Kubernetes once and every lab page follows. They previously existed only as a local copy in `ai-101`; this is now the only copy anywhere, and `local_copy.sh` no longer has a same-named repo-local file to shadow it with.


### PR DESCRIPTION
Closes the two follow-ups recorded against plan `0003` in `ai-101` — both about a CentralRepo merge changing more than its diff says.

## Why

Every push to `main` republishes `public.ecr.aws/k4n6m5h8/fortinet-hugo:latest`, and all 65 workshop repos build against that tag.

1. **`Dockerfile:10` was an unpinned `FROM hugomods/hugo:std`.** The Hugo version inside the published image was therefore decided by *when* a merge happened, not by anything in the diff. This is not hypothetical: on 2026-08-19 a merge moved the published image from Hugo 0.164.0 to 0.165.0, with nothing in the change asking for a Hugo bump.
2. **Neither image workflow had `paths-ignore`.** A README- or docs-only merge rebuilt and republished `latest` to every consumer.

## What changed

- `Dockerfile` → `FROM hugomods/hugo:std-0.165.0`. **0.165.0 is what production already runs**, so the pin is behaviourally inert today; it only makes the next Hugo bump an explicit, reviewable commit. Pinning the base also pins Alpine, so the `apk add python3 py3-pip tini-static` layer stops drifting.
- `image-build-push-prod.yaml` + `image-build-push-dev.yaml` → matching `paths-ignore`: root-level `*.md`, `docs/**`, `review/**`, and the three licence files. Everything under `scripts/`, `layouts/`, `assets/`, `i18n/`, `static/`, `archetypes/`, `themes/` and the `Dockerfile` itself **does** reach the image and is deliberately absent from the list.
- `RELEASE_NOTES.md` entry.

## Verification

Local `docker build --target=prod` against the pinned base succeeds and reports `hugo v0.165.0 linux/arm64 VendorInfo=hugomods` — byte-for-byte the same Hugo as the currently-published image, which is what makes this pin safe to land without a coordinated rebuild.

## Known consequence, accepted

`versioning.yml` still runs on every push to `main` and is deliberately **not** given `paths-ignore`, so a docs-only push still cuts a `vYY.Q.<letter>` tag and GitHub release. Image version letters can therefore skip — a tag may exist with no image built for it. Tagging a docs release is defensible; unifying the two triggers is a separate decision, not smuggled in here.

Merging this **will** rebuild the image (the `Dockerfile` changed), which is intended and is the last unpinned rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)