### PR TITLE
Gate the sidebar, prev/next, foreign-path arrivals and search on the reader's deployment path

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,18 +179,18 @@ Gotcha — never emit reader-facing prose from a shortcode that a page's `<meta 
 A standalone block that belongs to exactly one path, for content with no counterpart on the other path — where a `pathtabs` group would mean writing an empty or padded tab just to satisfy the every-path-exactly-once rule.
 
 ```
-{{< pathonly path="docker" >}}
+{{% pathonly path="docker" %}}
 ### Compose profiles
 The stack ships three profiles. Enable the GPU profile with
 `docker compose --profile gpu up -d`.
-{{< /pathonly >}}
+{{% /pathonly %}}
 ```
 
 Parameters:
 - `path`: Required. Must match a `key` in `deploymentPaths`; anything else is a build `errorf`.
 
 Behavior:
-- Note the delimiters: `{{< >}}`, unlike `pathtab`'s `{{% %}}`. The shortcode renders its own body with `RenderString` so the markdown works, and using `{{< >}}` keeps the *output* from being re-processed as markdown.
+- **`{{% %}}`, not `{{< >}}` — this is not stylistic.** The percent form hands the body back to the page's own markdown pass. The angle form would force the shortcode to render its body with `RenderString`, which runs in a separate render context, so headings inside the block never join the page's fragment set: an in-page `[link](#heading)` pointing into a `pathonly` block builds with `WARN … heading ID "…" not found` and does nothing when a reader clicks it, and the heading is absent from the page's table of contents.
 - Wraps its body in the same `.pathgate[data-path]` element the tab panels use, so there is one path-gating attribute in the codebase rather than two, gated by the same CSS.
 - Nesting inside `pathtab` or another `pathonly` is a build `errorf`, not a no-op. The enclosing block already restricts its body to one path, so a nested `pathonly` is either redundant (same key) or content that can never render (different key) — and the second case looks like working authoring right up until a reader reports missing steps.
 - An empty body is a build `errorf`, since it is indistinguishable from a gate silently hiding the wrong thing.
@@ -211,6 +211,14 @@ Two asymmetries here are deliberate:
 - **Every gate rule only ever hides — none forces `display` back on.** Sidebar `<li>`s and topbar buttons carry the theme's own responsive `display` rules (`[data-width-s="hide"]` and friends), so a rule re-showing the active path's element would defeat them at small widths and break the sidebar flyout. Reveal by `:not()`, never by re-assertion.
 
 A page-scoping decision is only visible in the built HTML as absent CSS, so it fails silently: if the generated selector does not byte-match the sidebar's real `data-nav-id`, the rule matches nothing and no error is raised.
+
+### Search
+Search results are filtered to the reader's path, because a search hit is the single most likely way a reader reaches a page the sidebar and prev/next gating just removed from their route.
+
+- Filtered client-side, in a wrapper around `window.relearn.search.adapter.search`. That is the only function both search surfaces go through — the dropdown suggestions (`search.js:178-181`) and the dedicated results page (`search.js:130-133`) — and the "N results found" count is computed from the array the wrapper returns, so it stays truthful.
+- The index entry shape is deliberately **not** extended. Relearn generates the index once from `site.Home` and feeds the same entries to two engines with independent field declarations — lunr's field list and the orama adapter's strict schema — so adding a field there is a theme-wide contract change. Instead `custom-header.html` emits a small `uri → path` side map for scoped pages only, keyed on the same `permalink.gotmpl` output the index itself uses for `uri`. If you ever do extend the index, note that lunr writes `page.index` onto every entry, so `index` is a field name that must never be added.
+- **With no path chosen, nothing is filtered.** Same reasoning as the sidebar: an undecided reader sees the whole site everywhere else, and a search that silently returned nothing would read as a broken index rather than as a gate.
+- Switching paths clears the autocomplete cache. `auto-complete.js` stores results on the `#R-search-by` element keyed by raw input value, and short-circuits any term whose shorter prefix cached zero results — so one term that legitimately found nothing on the old path would otherwise poison itself and every extension of it. If results are already on screen, the search re-runs.
 
 ### Repos that declare no paths
 `deploymentPaths` is absent from nearly every workshop repo, and all of the above is inert without it: no gate script, no gate CSS, one unclassed prev/next button each, and no `pathnav` classes. Output is byte-identical to a build without the feature.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,16 @@ Usage:
 {{< Xperts25Banner line1="Line A" line2="Line B" line3="Line C" >}}
 ```
 
-### pathtabs / pathtab
-Deployment-path tabs whose selection is remembered across the whole site. A reader picks a path once — Docker Compose vs Kubernetes, for example — and every other lab page shows that path's steps without asking again.
+### Deployment paths — pathtabs / pathtab / pathonly
+A reader picks a path once — Docker Compose vs Kubernetes, for example — and every other page follows that choice without asking again. There are three ways to scope content, and picking the wrong one is the main authoring mistake:
+
+| Form | Scope | Use when |
+|------|-------|----------|
+| `pathtabs` / `pathtab` | One block, every path | The paths are genuine alternatives to the same goal and a reader might want to see the other one. |
+| `pathonly` | One block, one path | The block only exists for one path and has no counterpart. |
+| `deploymentPath` front matter | A whole page | The entire page is one path's. |
+
+If the content is a *sentence* rather than a block, none of these fit — reword it to be path-neutral, or name both mechanisms. A block-level shortcode cannot wrap half a sentence, and gating a whole paragraph to hide one clause hides information the other path needed.
 
 Usage (two parts — the site param is a prerequisite):
 
@@ -167,6 +175,46 @@ Gotcha — renaming a `title` silently resets every returning reader. Relearn de
 
 Gotcha — never emit reader-facing prose from a shortcode that a page's `<meta name="description">` or the search index should not contain. Relearn builds the description from `.Summary | plainify` (`themes/hugo-theme-relearn/layouts/partials/meta.html:44`) and indexes the same content, so an earlier revision that put the chooser and the `<noscript>` warning inside the `pathtabs` shortcode pushed "JavaScript is disabled, so all 2 deployment paths are shown below" into the description and search snippet of every lab page, and added 120 words to each. Anything that is chrome rather than content belongs in a partial, outside `.Content`.
 
+### pathonly
+A standalone block that belongs to exactly one path, for content with no counterpart on the other path — where a `pathtabs` group would mean writing an empty or padded tab just to satisfy the every-path-exactly-once rule.
+
+```
+{{< pathonly path="docker" >}}
+### Compose profiles
+The stack ships three profiles. Enable the GPU profile with
+`docker compose --profile gpu up -d`.
+{{< /pathonly >}}
+```
+
+Parameters:
+- `path`: Required. Must match a `key` in `deploymentPaths`; anything else is a build `errorf`.
+
+Behavior:
+- Note the delimiters: `{{< >}}`, unlike `pathtab`'s `{{% %}}`. The shortcode renders its own body with `RenderString` so the markdown works, and using `{{< >}}` keeps the *output* from being re-processed as markdown.
+- Wraps its body in the same `.pathgate[data-path]` element the tab panels use, so there is one path-gating attribute in the codebase rather than two, gated by the same CSS.
+- Nesting inside `pathtab` or another `pathonly` is a build `errorf`, not a no-op. The enclosing block already restricts its body to one path, so a nested `pathonly` is either redundant (same key) or content that can never render (different key) — and the second case looks like working authoring right up until a reader reports missing steps.
+- An empty body is a build `errorf`, since it is indistinguishable from a gate silently hiding the wrong thing.
+- It may sit inside a plain (non-path) `tabs` group.
+
+### deploymentPath front matter — scoping a whole page
+Set `deploymentPath: docker` (or any declared `key`) in a page's front matter and the page belongs to that path alone. A key not in `deploymentPaths` is a build `errorf` — a page scoped to a path that does not exist is hidden from every reader.
+
+This does more than gate the body; it removes the page from the other path's route through the site:
+
+- **Sidebar.** `custom-header.html` generates one CSS rule per (scoped page × other path) hiding that page's `<li>`. The selector is keyed on the permalink from `permalink.gotmpl` — the same partial `menu.html` builds `data-nav-id` from — *not* on `.RelPermalink`, which omits the `index.html` that `disableExplicitIndexURLs = false` appends to every section page.
+- **Prev/next.** Relearn resolves these at build time and honours only `params.hidden`, so hiding a page from the sidebar while leaving it on the linear walk marches the reader into a page the sidebar says does not exist. `layouts/partials/pathnav/step.gotmpl` re-runs relearn's walk once per path, skipping foreign pages, and `topbar/button/{prev,next}.html` emit one button per path plus a `pathnav--any` for the no-choice state; CSS reveals the matching one.
+- **Arriving anyway.** A bookmark, a search result or someone else's link can still land a reader on a foreign page, so `content-header.html` emits a `.pathmiss` banner per foreign state — naming both the page's path and the reader's — with a switch button. The content still renders below it: a blank page with a switcher reads as a broken build, not as a gate. The blocking chooser is suppressed on these pages, so an undecided reader gets one prompt rather than two.
+
+Two asymmetries here are deliberate:
+
+- **Navigation is not default-deny, unlike step content.** With no choice stored, every page shows in the sidebar and prev/next is the theme's own unfiltered walk. Default-deny is right for steps, where showing both paths is the bug this whole mechanism exists to fix; it is wrong for navigation, where it would present a workshop with pages missing from the table of contents and no explanation.
+- **Every gate rule only ever hides — none forces `display` back on.** Sidebar `<li>`s and topbar buttons carry the theme's own responsive `display` rules (`[data-width-s="hide"]` and friends), so a rule re-showing the active path's element would defeat them at small widths and break the sidebar flyout. Reveal by `:not()`, never by re-assertion.
+
+A page-scoping decision is only visible in the built HTML as absent CSS, so it fails silently: if the generated selector does not byte-match the sidebar's real `data-nav-id`, the rule matches nothing and no error is raised.
+
+### Repos that declare no paths
+`deploymentPaths` is absent from nearly every workshop repo, and all of the above is inert without it: no gate script, no gate CSS, one unclassed prev/next button each, and no `pathnav` classes. Output is byte-identical to a build without the feature.
+
 ## Theme variants
 
 Set `themeVariant` in `scripts/repoConfig.json` to control the sidebar header appearance. Available values:
@@ -215,7 +263,7 @@ The `CloudCSEMovie` variant replaces the static header image with a looping MP4 
 - `quizUrl`: Base URL for `quizframe`.
 - `videoHeaderSrc`: Path to the sidebar header background MP4 (`CloudCSEMovie` theme only).
 - `videoHeaderInterval`: Seconds between video play cycles (`CloudCSEMovie` theme only, default `60`).
-- `deploymentPaths`: List of `{key, title}` objects defining the path vocabulary for `pathtabs`. Required by that shortcode — the build fails if it is absent.
+- `deploymentPaths`: List of `{key, title}` objects defining the path vocabulary for `pathtabs`, `pathonly` and the `deploymentPath` page param. Required by all three — the build fails if it is absent. Declaring it is also what switches the whole gate on; a repo without it builds byte-identically to one built before the feature existed. Keys are used as CSS class suffixes as well as attribute values, so a key must start with a letter and contain only letters, digits, hyphens and underscores.
 - `errorignore`: List of regex strings. Relearn matches each one against the offending URL in `themes/hugo-theme-relearn/layouts/partials/_relearn/urlErrorReport.gotmpl:5` and suppresses the link/image/include/openapi warning or error when any matches.
 
 ## Cookie overview

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,30 +4,47 @@
 
 ## [Unreleased]
 
-### feat(shortcodes): pathtabs / pathtab with locked-path banner, upstreamed from ai-101
+### feat(shortcodes): single deployment path per reader — pathtabs / pathonly / deploymentPath
 
-`pathtabs` / `pathtab` render a deployment-path tab group whose selection is remembered site-wide, so a reader picks Docker vs Kubernetes once and every lab page follows. They previously existed only as a local copy in `ai-101`; this is now the only copy anywhere, and `local_copy.sh` no longer has a same-named repo-local file to shadow it with.
+A reader picks Docker vs Kubernetes once and every page of the site follows that choice. This started as `pathtabs` / `pathtab` upstreamed from `ai-101` — previously a local copy there, now the only copy anywhere, and `local_copy.sh` no longer has a same-named repo-local file to shadow it with.
 
-Two changes from `ai-101`'s version make the shortcode genuinely shared rather than one workshop's component: `groupid` is now a parameter (default `deploy-path`) so a site can carry two independent locked choices, and the hardcoded `docker`/`k8s` fallback vocabulary is gone — a missing `deploymentPaths` is a build `errorf` instead, so no repo silently inherits another repo's paths.
+**The problem this exists to fix:** workshop participants were doing the Docker steps *and* the Kubernetes steps, because both tabs were on screen. Anything that leaves the other path reachable is the bug, so the gate is **default-deny for content**: until a path is chosen, no path's steps are visible anywhere on the site, and a page carrying a path block renders a blocking chooser instead. There is deliberately no default path.
 
-New in this version: a `.pathlock__banner` above the tab nav reading `🔒 Your path: <VALUE>` plus `Locked in — every lab page follows this choice.` `<VALUE>` live-updates as the reader switches tabs. The banner observes tab state via a `MutationObserver` on the panel plus an initial read at install time; it never calls `switchTab` and never writes `localStorage`, because relearn only persists a selection when the click event is real. It degrades to the server-rendered first tab with JavaScript off and is hidden in print. CSS and JS are emitted by the shortcode itself, once per page, guarded with `.Page.Store` — except the one `@media print` rule that hides the banner, which is emitted per block on purpose: Hugo renders content once per output format while `.Page.Store` is shared across them, so a guarded rule reaches only whichever format builds first and would leave the banner visible in `layouts/_default/allpages.html`'s whole-site PRINT page.
+**Everything is server-rendered and CSS-gated.** An inline synchronous `<script>` in `<head>` reads `localStorage[absBaseUri + '/deployment-path']` and sets `<html data-deployment-path>` before first paint — the same pre-paint pattern relearn uses for `themeVariant`. Every path's markup is emitted once and CSS reveals whichever matches. Nothing mutates the DOM after load, so there is no frame in which the wrong path is on screen. The corollary is that any per-path variation must be emitted once per path at build time, because there is one HTML output per page and the reader's path is known only client-side; that is why prev/next emits one button per path rather than resolving "the reader's path".
 
-Two new optional site params support it and close a long-standing build warning: `deploymentPaths` (the path vocabulary) and `errorignore` (a list of regexes relearn has always honoured but CentralRepo never emitted — it suppresses the local-URL warning for non-page targets like a PDF, where the suggested `pageRef` does not apply). Both are omitted from `hugo.toml` entirely when absent, so no existing site changes behaviour.
+Three authoring forms, covered in the README with guidance on which to reach for:
+
+- `pathtabs` / `pathtab` — alternatives to the same goal. Every declared path exactly once per block, or the build fails, so a reader can never be silently shown the other path's steps. Once a path is chosen the relearn tab nav is hidden and a `.pathlock__banner` reads `Your path: <VALUE>`; the switcher in `content-header.html` becomes the only control that writes the choice, so there is one control writing one state instead of two.
+- `pathonly` — a standalone one-path block, for content with no counterpart. Nesting it inside a `pathtab` or another `pathonly` is an `errorf`: same key is redundant, different key is unreachable, and the second looks like working authoring until a reader reports missing steps.
+- `deploymentPath` front matter — a whole page. This also removes the page from the other path's **sidebar** and from its **prev/next** walk, and renders a `.pathmiss` banner naming both paths with a switch button when a reader arrives anyway via a bookmark or a search result.
+
+Hiding a page from the sidebar without also filtering prev/next would march the reader into a page the sidebar says does not exist, so `layouts/partials/pathnav/step.gotmpl` re-runs relearn's walk once per path. The sidebar selector is keyed on `permalink.gotmpl` — the partial `menu.html` itself builds `data-nav-id` from — not `.RelPermalink`, which omits the `index.html` that `disableExplicitIndexURLs = false` appends to every section page.
+
+Two asymmetries worth knowing before extending this: **navigation is not default-deny** (with no choice stored, the sidebar and prev/next are the theme's own unfiltered behaviour, because a table of contents with pages silently missing reads as a broken build), and **every gate rule only ever hides** — sidebar `<li>`s and topbar buttons carry the theme's own responsive `display` rules, so re-asserting `display` for the active path would defeat them at small widths.
+
+With JavaScript off, nothing sets the attribute and none of the gating applies: **all** paths render, stacked, with a `<noscript>` warning naming them in order. Failing open is deliberate — unreadable-but-complete beats silently empty. Print carries exactly one path.
+
+Two new optional site params support it and close a long-standing build warning: `deploymentPaths` (the path vocabulary) and `errorignore` (a list of regexes relearn has always honoured but CentralRepo never emitted — it suppresses the local-URL warning for non-page targets like a PDF, where the suggested `pageRef` does not apply). Both are omitted from `hugo.toml` entirely when absent.
 
 `scripts/static.yml` also becomes the canonical workshop-repo workflow template rather than a copy of CentralRepo's own image build.
 
-**Blast radius:** merging to `main` rebuilds the prod ECR image that ~12 workshop repos build against. Verified locally against `hugotester-local` first.
+**Blast radius:** merging to `main` rebuilds the prod ECR image that ~65 workshop repos build against. `deploymentPaths` is absent from all but `ai-101`, and without it the whole mechanism is inert — no gate script, no gate CSS, one unclassed prev/next button each. Verified by building `faig-training-workshop` against both the unmodified and modified theme: **byte-identical across all 36 pages** once the four known per-build noise tokens are normalised.
 
 **Files changed**
 | File | Change |
 |------|--------|
-| `layouts/shortcodes/pathtabs.html` | New — path tab group + locked-path banner, inline CSS/JS once per page |
+| `layouts/partials/custom-header.html` | The gate: pre-paint script, all gating CSS (panels, sidebar, prev/next, chooser, banners), `deploymentPaths` key-format and page-key validation |
+| `layouts/partials/content-header.html` | Blocking chooser, `<noscript>` warning, path switcher, per-foreign-state `.pathmiss` banners — all outside `.Content` so none of it reaches `<meta name="description">` or the search index |
+| `layouts/shortcodes/pathtabs.html` | New — path tab group; markup only, assets moved to `custom-header.html` |
 | `layouts/shortcodes/pathtab.html` | New — collects one path's content for the parent `pathtabs` block |
+| `layouts/shortcodes/pathonly.html` | New — standalone one-path block, same `.pathgate[data-path]` contract as the panels |
+| `layouts/partials/pathnav/step.gotmpl` | New — relearn's prev/next walk, re-run per path, skipping foreign pages |
+| `layouts/partials/topbar/button/prev.html`, `next.html` | One button variant per path plus `pathnav--any`; unclassed and byte-identical when no paths are declared |
 | `scripts/templates/hugo.jinja` | Emit optional `errorignore` and `deploymentPaths` params |
 | `scripts/repoConfig.schema.json` | Add `errorignore` and `deploymentPaths` (required — `additionalProperties: false`) |
 | `scripts/static.yml` | Now the workshop template: ECR pull with backoff, `trap cleanup EXIT`, `docker wait` status, `::error::` on failure, `image_variant` input |
 | `scripts/batch_repo_update.py` | `FILES_TO_COPY` sources `scripts/static.yml`, matching `update_scripts.sh:14` |
-| `README.md` | New `### pathtabs / pathtab` section, both new site params, and the `local_copy.sh` shadowing gotcha |
+| `README.md` | New deployment-paths section: the three forms and when to use each, page scoping, the two asymmetries, and the `local_copy.sh` shadowing gotcha |
 
 ---
 

--- a/layouts/partials/content-header.html
+++ b/layouts/partials/content-header.html
@@ -1,4 +1,8 @@
-{{- $hasPathtabs := .HasShortcode "pathtabs" }}
+{{- $page := . }}
+{{/* Either shortcode gates content on this page, so either one means the reader
+     cannot proceed without choosing and must be offered the chooser. */}}
+{{- $hasPathtabs := or (.HasShortcode "pathtabs") (.HasShortcode "pathonly") }}
+{{- $ownPath := .Params.deploymentPath | default "" }}
 {{- $titles := slice }}
 {{- range .Site.Params.deploymentPaths }}{{ $titles = $titles | append .title }}{{ end }}
 {{- with .Site.Params.deploymentPaths }}
@@ -18,6 +22,10 @@
     {{ delimit $titles ", " ", then " }}. They are alternatives, not a sequence — follow one path only.
   </div>
 </noscript>
+{{/* Suppressed on a page that is itself scoped to one path: the pathmiss banner
+     below already prompts an undecided reader there, and two competing prompts on
+     one screen is how a reader ends up choosing twice. */}}
+{{- if not $ownPath }}
 <div class="pathgate-chooser" role="group" aria-label="Choose your deployment path">
   <div class="pathgate-chooser__lead">Choose your deployment path</div>
   <div class="pathgate-chooser__hint">This page's steps are hidden until you pick one. Every other lab page then follows the same choice, and you can switch at any time from the header.</div>
@@ -27,6 +35,38 @@
     {{- end }}
   </div>
 </div>
+{{- end }}
+{{- end }}
+{{/* A page whose front matter scopes it to one path. It is reachable by a reader
+     on another path -- a bookmark, a search result, a link in someone else's
+     notes -- and the sidebar and prev/next gating cannot prevent that. One banner
+     per foreign state, revealed by CSS, because which state applies is only known
+     client-side. The page's own content still renders below: a blank page with a
+     switcher reads as a broken build, not as a gate. */}}
+{{- with $ownPath }}
+  {{- $own := . }}
+  {{- $ownTitle := "" }}
+  {{- range $.Site.Params.deploymentPaths }}{{ if eq .key $own }}{{ $ownTitle = .title }}{{ end }}{{ end }}
+<div class="pathmiss" data-for-path="" role="note">
+  <strong>This page is part of the {{ $ownTitle }} path.</strong>
+  You have not chosen a path yet. Pick one and every page follows it, including the sidebar and the next/previous buttons.
+  <div class="pathmiss__actions">
+    {{- range $.Site.Params.deploymentPaths }}
+    <button type="button" class="pathgate-chooser__btn" data-choose-path="{{ .key }}">{{ .title }}</button>
+    {{- end }}
+  </div>
+</div>
+  {{- range $.Site.Params.deploymentPaths }}
+    {{- if ne .key $own }}
+<div class="pathmiss" data-for-path="{{ .key }}" role="note">
+  <strong>This page is part of the {{ $ownTitle }} path, and you are following {{ .title }}.</strong>
+  Nothing on this page applies to your path — you have most likely arrived from a bookmark or a search result. Use the sidebar to get back, or switch paths.
+  <div class="pathmiss__actions">
+    <button type="button" class="pathgate-chooser__btn" data-choose-path="{{ $own }}">Switch to {{ $ownTitle }}</button>
+  </div>
+</div>
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{/* The switcher goes on every page, not only pages that use pathtabs, because
      the choice is site-wide: a reader who picks the wrong path otherwise has to

--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -476,9 +476,17 @@ html[data-deployment-path="{{ .key }}"] .pathmiss[data-for-path="{{ .key }}"] {
       {{- with and $p $p.File $p.File.Filename }}{{ $file = . }}{{ end }}
       {{- errorf "%s: this page is scoped to the %q path but has no permalink, so menu.html renders it headless with data-nav-id=\"\" (:149). A rule keyed on the empty string would hide every headless entry in the sidebar, not this one." $file $own }}
     {{- end }}
+    {{/* `:not(.active)` keeps the reader's own location in the table of contents.
+         A reader on another path can still arrive here from a bookmark or a search
+         result, and hiding the entry for the page they are currently reading
+         leaves the sidebar with nothing highlighted -- which reads as a broken
+         build, not as a gate. It leaks nothing: the content-header pathmiss banner
+         already states the page belongs to the other path, and an entry for the
+         page already on screen reveals no steps the reader could not see anyway.
+         `active` is the first class on the <li> (menu.html:149,184,309,345). */}}
     {{- range $paths }}
       {{- if ne .key $own }}
-html[data-deployment-path="{{ .key }}"] #R-sidebar li[data-nav-id="{{ $navid | safeCSS }}"] {
+html[data-deployment-path="{{ .key }}"] #R-sidebar li[data-nav-id="{{ $navid | safeCSS }}"]:not(.active) {
   display: none;
 }
       {{- end }}

--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -461,6 +461,21 @@ html[data-deployment-path="{{ .key }}"] .pathmiss[data-for-path="{{ .key }}"] {
          cosmetic: permalink.gotmpl appends `index.html` to any link ending in "/"
          while `disableExplicitIndexURLs` is false, which is every section page. */}}
     {{- $navid := partial "permalink.gotmpl" (dict "to" $p) }}
+    {{/* Both of the following are errors rather than best-effort rules, because
+         the failure they prevent is silent in both directions: a selector keyed
+         on the wrong value matches no element and hides nothing, and CSS reports
+         neither. `data-nav-id` is the only page identity on the <li>, so there
+         is no second attribute to fall back to. */}}
+    {{- if or $p.Params.menuPageRef $p.Params.menuUrl }}
+      {{- $file := "[virtual file]" }}
+      {{- with and $p $p.File $p.File.Filename }}{{ $file = . }}{{ end }}
+      {{- errorf "%s: a page cannot combine deploymentPath with menuPageRef/menuUrl. Those params make the sidebar entry a crosslink, so menu.html keys its data-nav-id on the crosslink target (:130,:133,:137) rather than on the page's own permalink, and the generated rule would match nothing -- the page would stay visible to every path with no error. Drop one of the two." $file }}
+    {{- end }}
+    {{- if not $navid }}
+      {{- $file := "[virtual file]" }}
+      {{- with and $p $p.File $p.File.Filename }}{{ $file = . }}{{ end }}
+      {{- errorf "%s: this page is scoped to the %q path but has no permalink, so menu.html renders it headless with data-nav-id=\"\" (:149). A rule keyed on the empty string would hide every headless entry in the sidebar, not this one." $file $own }}
+    {{- end }}
     {{- range $paths }}
       {{- if ne .key $own }}
 html[data-deployment-path="{{ .key }}"] #R-sidebar li[data-nav-id="{{ $navid | safeCSS }}"] {
@@ -716,6 +731,112 @@ html[data-deployment-path=""] .topbar-button.pathnav:not(.pathnav--any) {
     if (!btn) { return; }
     e.preventDefault();
     window.fortiPath.set(btn.getAttribute('data-choose-path'));
+  });
+})();
+</script>
+
+{{/* Search scoping. The sidebar and prev/next gating above is worthless while
+     search still offers the other path's pages: a search hit is exactly the
+     "arrived from somewhere else" case the pathmiss banner exists to catch, and
+     it is the one the reader is most likely to hit.
+
+     Filtered client-side rather than by building one index per path, because the
+     index is generated once from site.Home (dependencies/search.html:60-65) and
+     is shared by every page, so there is no per-path build hook to use. The
+     filter also deliberately does NOT extend the index entry shape: relearn
+     resolves the index template through params.search.index.template and feeds
+     the same entries to two different engines -- lunr declares its own field
+     list (search-lunr.js:68-89) and the orama adapter a strict schema
+     (search-orama-esm.mjs:32-56) -- so adding a field there is a theme-wide
+     contract change. `uri` is already a unique per-page identity that reaches
+     the results, and one small side map keyed on it needs neither engine to
+     agree to anything. (lunr also writes `page.index` onto every entry, so
+     `index` is a field name that must never be added.) */}}
+{{- $scoped := slice }}
+{{- range $p := site.Pages }}
+  {{- with $p.Params.deploymentPath }}
+    {{- $scoped = $scoped | append (dict "uri" (partial "permalink.gotmpl" (dict "to" $p)) "path" .) }}
+  {{- end }}
+{{- end }}
+<script>
+(function () {
+  // uri is built by the same partial the search index uses for its own `uri`
+  // (_relearn_searchindex.js:12), so these match by string equality with no
+  // normalising. Only path-scoped pages are listed; an absent entry means the
+  // page belongs to every path, which is the overwhelming majority.
+  var SCOPED = [
+    {{- range $i, $e := $scoped }}{{ if $i }},{{ end }}
+    { uri: {{ $e.uri }}, path: {{ $e.path }} }
+    {{- end }}
+  ];
+  var OWNER = {};
+  for (var i = 0; i < SCOPED.length; i++) { OWNER[SCOPED[i].uri] = SCOPED[i].path; }
+
+  var root = document.documentElement;
+
+  // No choice stored means no filtering, which diverges from the default-deny
+  // rule the content gate follows. Deliberate: a reader who has not chosen yet
+  // is being shown the whole site everywhere else, and a search that silently
+  // returned nothing would read as a broken index rather than as a gate.
+  function allowed(page) {
+    var active = (window.fortiPath && window.fortiPath.get()) || '';
+    if (!active) { return true; }
+    var owner = page && page.uri ? OWNER[page.uri] : null;
+    return !owner || owner === active;
+  }
+
+  // One wrap covers both surfaces. The dropdown (search.js:178-181) and the
+  // dedicated results page (search.js:130-133) are the only two callers and
+  // both await this same function, and the "N results found" count is computed
+  // from the array we return (search.js:133), so it stays truthful without a
+  // second patch.
+  function install() {
+    var s = window.relearn && window.relearn.search;
+    if (!s || !s.adapter || typeof s.adapter.search !== 'function') { return; }
+    if (s.adapter.fortiPathFiltered) { return; }
+    var inner = s.adapter.search;
+    s.adapter.search = async function () {
+      var results = await inner.apply(this, arguments);
+      if (!Array.isArray(results)) { return results; }
+      return results.filter(function (r) { return allowed(r && r.page); });
+    };
+    s.adapter.fortiPathFiltered = true;
+  }
+
+  // The adapter is registered by a deferred script (search-lunr.js:155-157), so
+  // it does not exist while this inline block parses. It always exists by
+  // DOMContentLoaded, since every deferred script runs first. Presence-checked
+  // rather than assumed because search.html:57,115 omit the whole bundle when a
+  // site disables search.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', install, { once: true });
+  } else {
+    install();
+  }
+
+  // documentElement, not window: fortiPath dispatches a CustomEvent, which does
+  // not bubble.
+  root.addEventListener('forti:pathchange', function () {
+    // auto-complete.js hangs `cache` straight off the input element (:75) and
+    // keys it on the raw input value (:152-154). Worse than staleness, :226-233
+    // short-circuits any term whose shorter prefix cached zero results, so one
+    // term that legitimately found nothing on the old path poisons itself and
+    // every extension of it. Neither survives a path change, and the instance
+    // that owns destroy() is discarded at construction (search.js:173), so
+    // clearing the element's own properties is both the available lever and
+    // the sufficient one.
+    var box = document.getElementById('R-search-by');
+    if (box) {
+      box.cache = {};
+      box.last_val = '';
+    }
+    // Results already on screen were filtered for the previous path. The
+    // results page is the one place a reader can switch path while looking at
+    // matches, so re-run rather than leave them contradicting the new choice.
+    if (document.getElementById('R-searchresults') &&
+        window.relearn && typeof window.relearn.executeTriggeredSearch === 'function') {
+      window.relearn.executeTriggeredSearch();
+    }
   });
 })();
 </script>

--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -383,6 +383,108 @@ html[data-deployment-path="{{ .key }}"] .pathswitch__btn:not([data-choose-path="
 }
 {{- end }}
 
+/* Standalone path-scoped blocks -- the `pathonly` shortcode, for prose and whole
+   sections that belong to one path but do not warrant a tabs group. Same
+   default-deny shape as the panels above, and the same `.pathgate[data-path]`
+   attribute, so the path key is read from one attribute name site-wide. */
+html[data-deployment-path] .pathonly {
+  display: none;
+}
+{{- range . }}
+html[data-deployment-path="{{ .key }}"] .pathonly[data-path="{{ .key }}"] {
+  display: block;
+}
+{{- end }}
+
+/* A page that belongs to one path, opened by a reader following another -- from a
+   bookmark, a search result, or a link in someone else's notes. The page still
+   renders: a blank page with a switcher is worse than the wrong page with an
+   explanation, because the reader cannot tell a gate from a broken build. */
+.pathmiss {
+  display: none;
+  margin: 0 0 .8rem 0;
+  padding: .6rem .8rem;
+  border: 1px solid #b58900;
+  border-left: 4px solid #b58900;
+  border-radius: 3px;
+  background: rgba(181, 137, 0, .1);
+  line-height: 1.4;
+}
+.pathmiss__actions {
+  margin-top: .5rem;
+}
+html[data-deployment-path=""] .pathmiss[data-for-path=""] {
+  display: block;
+}
+{{- range . }}
+html[data-deployment-path="{{ .key }}"] .pathmiss[data-for-path="{{ .key }}"] {
+  display: block;
+}
+{{- end }}
+
+{{- $paths := . }}
+{{- $keys := slice }}
+{{- range . }}{{ $keys = $keys | append .key }}{{ end }}
+{{- range . }}
+  {{/* The key becomes part of a CSS class name below, not only an attribute
+       value, so anything that is not a bare identifier would silently produce a
+       selector that never matches. Fail the build instead. */}}
+  {{- if not (findRE `^[A-Za-z][A-Za-z0-9_-]*$` .key) }}
+    {{- errorf "deploymentPaths key %q is not usable: keys must start with a letter and contain only letters, digits, hyphens and underscores, because they are used as CSS class-name suffixes as well as attribute values." .key }}
+  {{- end }}
+{{- end }}
+
+/* Sidebar. A page declaring `deploymentPath` in front matter is hidden from the
+   sidebar of every other path. Build-time CSS keyed on the permalink, so there is
+   no flash and no JS: the reader never sees the other path's pages appear and
+   then vanish.
+
+   These rules only ever hide. `.topbar-button` and the sidebar entries carry the
+   theme's own responsive display rules (`[data-width-s="hide"]` and friends, and
+   the flyout's own state), and a rule that forced `display` back on for the
+   active path would defeat them at small widths.
+
+   Nothing is hidden while data-deployment-path is "" -- a reader who has not
+   chosen yet gets the full table of contents. Default-deny is right for steps,
+   where showing both paths is the original failure; it is wrong for navigation,
+   where it would present a workshop with pages missing and no way to tell why. */
+{{- range $p := site.Pages }}
+  {{- with $p.Params.deploymentPath }}
+    {{- $own := . }}
+    {{- if not (in $keys $own) }}
+      {{- $file := "[virtual file]" }}
+      {{- with and $p $p.File $p.File.Filename }}{{ $file = . }}{{ end }}
+      {{- errorf "%s: deploymentPath: %q is not one of the declared deploymentPaths %v. A page scoped to a path that does not exist is hidden from every reader's sidebar." $file $own $keys }}
+    {{- end }}
+    {{/* data-nav-id is `{{ $url }}` from the same partial the theme's menu.html
+         uses (:149,:184,:309,:345) -- not `.RelPermalink`. The difference is not
+         cosmetic: permalink.gotmpl appends `index.html` to any link ending in "/"
+         while `disableExplicitIndexURLs` is false, which is every section page. */}}
+    {{- $navid := partial "permalink.gotmpl" (dict "to" $p) }}
+    {{- range $paths }}
+      {{- if ne .key $own }}
+html[data-deployment-path="{{ .key }}"] #R-sidebar li[data-nav-id="{{ $navid | safeCSS }}"] {
+  display: none;
+}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+/* prev/next. topbar/button/{prev,next}.html emit one button per path plus a
+   `pathnav--any` one for the no-choice state; all but the matching one are
+   hidden. Hiding a page from the sidebar while leaving it on the linear walk
+   would march the reader into a page the sidebar says does not exist, which is
+   why this ships with the sidebar rules above and never after them. */
+{{- range . }}
+html[data-deployment-path="{{ .key }}"] .topbar-button.pathnav:not(.pathnav--{{ .key }}) {
+  display: none;
+}
+{{- end }}
+html[data-deployment-path=""] .topbar-button.pathnav:not(.pathnav--any) {
+  display: none;
+}
+
 .pathswitch {
   align-items: center;
   flex-wrap: wrap;
@@ -493,6 +595,7 @@ html[data-deployment-path="{{ .key }}"] .pathswitch__btn:not([data-choose-path="
 @media print {
   html[data-deployment-path] .pathlock__banner,
   html[data-deployment-path] .pathgate-chooser,
+  html[data-deployment-path] .pathmiss,
   html[data-deployment-path] .pathswitch {
     display: none;
   }
@@ -505,7 +608,13 @@ html[data-deployment-path="{{ .key }}"] .pathswitch__btn:not([data-choose-path="
      `#R-body .pathlock .tab-content` is (1,2,1), which beats the theme's
      `#R-body .tab-content.active` (1,2,0). <style> inside <noscript> inside
      <head> is valid HTML and is the only way to branch CSS on JS availability
-     without a frame of wrong paint. */}}
+     without a frame of wrong paint.
+
+     `.pathonly`, the sidebar and the prev/next buttons need nothing here: each of
+     those hide rules is keyed on `html[data-deployment-path]` *existing*, so with
+     JavaScript off none of them apply and the content is simply all present. Only
+     the tab panels need an override, because relearn's own stylesheet marks tab
+     #1 active server-side whether this gate runs or not. */}}
 <noscript><style>
 #R-body .pathlock .tab-content { display: block; }
 #R-body .pathlock .tab-nav { display: none; }

--- a/layouts/partials/pathnav/step.gotmpl
+++ b/layouts/partials/pathnav/step.gotmpl
@@ -1,0 +1,59 @@
+{{- /*
+  Return the next or previous page for one deployment path, skipping any page
+  whose `deploymentPath` front matter names a different path.
+
+  Why a walk rather than a filter: there is one HTML output per page and the
+  reader's path is only known client-side, so prev/next cannot be resolved for
+  "the reader's path" at build time. The callers run this once per declared path
+  and emit one button per result; the gate CSS in custom-header.html reveals the
+  one that matches. Pages with no `deploymentPath` belong to every path and are
+  always accepted, so a site that declares no paths never reaches this partial.
+
+  Arguments:
+    page  the page to walk from
+    dir   "next" or "prev"
+    path  the deployment-path key to walk for; "" means accept anything, which
+          reproduces the theme's own unfiltered result
+
+  Returns a Page, or "" when the walk runs out.
+*/ -}}
+{{- $page := .page }}
+{{- $dir := .dir }}
+{{- $key := .path }}
+{{- $walker := cond (eq $dir "next") "_relearn/pageNext.gotmpl" "_relearn/pagePrev.gotmpl" }}
+{{- $cur := $page }}
+{{- $found := "" }}
+{{- $done := false }}
+{{- /*
+  Bounded rather than open-ended, because Go templates have no `while` and two of
+  the terminating conditions are the walkers' own quirks rather than anything
+  this partial controls: pageNext returns "" at the end of the site, while
+  pagePrev falls back to site.Home (`_relearn/pagePrev.gotmpl:12`) and so returns
+  the same page forever once it gets there. 24 is far above any plausible run of
+  consecutive same-path pages; exhausting it warns rather than failing, because a
+  missing prev/next button is a worse outcome than a slightly wrong one.
+*/ -}}
+{{- range seq 24 }}
+  {{- if not $done }}
+    {{- $cand := partialCached $walker $cur $cur.Path }}
+    {{- if not $cand }}
+      {{- $done = true }}
+    {{- else if eq $cand.Path $cur.Path }}
+      {{- $done = true }}
+    {{- else }}
+      {{- $cp := $cand.Params.deploymentPath | default "" }}
+      {{- if or (not $key) (not $cp) (eq $cp $key) }}
+        {{- $found = $cand }}
+        {{- $done = true }}
+      {{- else }}
+        {{- $cur = $cand }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if not $done }}
+  {{- $file := "[virtual file]" }}
+  {{- with and $page $page.File $page.File.Filename }}{{ $file = . }}{{ end }}
+  {{- warnf "%s: gave up looking for the %s page on the %q path after 24 hops; the %s button will be disabled there. Either the site has a run of more than 24 consecutive same-path pages, or a page's deploymentPath is wrong." $file $dir $key $dir }}
+{{- end }}
+{{- return $found }}

--- a/layouts/partials/topbar/button/next.html
+++ b/layouts/partials/topbar/button/next.html
@@ -1,28 +1,46 @@
 {{- $onwidths := cond (isset . "onwidths") .onwidths "show" }}
 {{- $onwidthm := cond (isset . "onwidthm") .onwidthm "show" }}
 {{- $onwidthl := cond (isset . "onwidthl") .onwidthl "show" }}
-{{- with .page }}
+{{- $page := .page }}
+{{- with $page }}
 	{{- $show := not (.Param "disableNextPrev") }}
 	{{- if $show }}
 		{{- $endarrow := "🡒" }}
 		{{- if eq (.Language.Direction | default (T "Reading-direction") | default "ltr") "rtl" }}
 			{{- $endarrow = "🡐" }}
 		{{- end }}
-        {{- $next := partialCached "_relearn/pageNext.gotmpl" . .Path }}
-		{{- $nextTitle := partial "title.gotmpl" (dict "page" $next "outputFormat" "html") }}
-		{{- $href := "" }}
-		{{- with (and $next $next.Path) }}
-			{{- $href = . }}
+		{{/* See prev.html for why this emits one button per path. The two must stay
+		     symmetrical: a next button that skips a page while prev does not walks
+		     the reader into a page they cannot get back out of. */}}
+		{{- $variants := slice (dict "key" "" "class" "") }}
+		{{- with site.Params.deploymentPaths }}
+			{{- $variants = slice (dict "key" "" "class" "pathnav pathnav--any") }}
+			{{- range . }}
+				{{- $variants = $variants | append (dict "key" .key "class" (printf "pathnav pathnav--%s" .key)) }}
+			{{- end }}
 		{{- end }}
-		{{- partial "topbar/func/button.html" (dict
-			"page" .
-			"class" "topbar-button-next"
-			"href" $href
-			"icon" "chevron-right"
-			"onwidths" $onwidths
-			"onwidthm" $onwidthm
-			"onwidthl" $onwidthl
-			"hint" (printf "%s (%s)" $nextTitle ($endarrow | safeHTML))
-		)}}
+		{{- range $variants }}
+			{{- $next := "" }}
+			{{- if .key }}
+				{{- $next = partial "pathnav/step.gotmpl" (dict "page" $page "dir" "next" "path" .key) }}
+			{{- else }}
+				{{- $next = partialCached "_relearn/pageNext.gotmpl" $page $page.Path }}
+			{{- end }}
+			{{- $nextTitle := partial "title.gotmpl" (dict "page" $next "outputFormat" "html") }}
+			{{- $href := "" }}
+			{{- with (and $next $next.Path) }}
+				{{- $href = . }}
+			{{- end }}
+			{{- partial "topbar/func/button.html" (dict
+				"page" $page
+				"class" (trim (printf "topbar-button-next %s" .class) " ")
+				"href" $href
+				"icon" "chevron-right"
+				"onwidths" $onwidths
+				"onwidthm" $onwidthm
+				"onwidthl" $onwidthl
+				"hint" (printf "%s (%s)" $nextTitle ($endarrow | safeHTML))
+			)}}
+		{{- end }}
 	{{- end }}
 {{- end }}

--- a/layouts/partials/topbar/button/prev.html
+++ b/layouts/partials/topbar/button/prev.html
@@ -1,28 +1,48 @@
 {{- $onwidths := cond (isset . "onwidths") .onwidths "show" }}
 {{- $onwidthm := cond (isset . "onwidthm") .onwidthm "show" }}
 {{- $onwidthl := cond (isset . "onwidthl") .onwidthl "show" }}
-{{- with .page }}
+{{- $page := .page }}
+{{- with $page }}
 	{{- $show := not (.Param "disableNextPrev") }}
 	{{- if $show }}
 		{{- $startarrow := "🡐" }}
 		{{- if eq (.Language.Direction | default (T "Reading-direction") | default "ltr") "rtl" }}
 			{{- $startarrow = "🡒" }}
 		{{- end }}
-        {{- $prev := partialCached "_relearn/pagePrev.gotmpl" . .Path }}
-		{{- $prevTitle := partial "title.gotmpl" (dict "page" $prev "outputFormat" "html") }}
-		{{- $href := "" }}
-		{{- with (and $prev $prev.Path) }}
-			{{- $href = . }}
+		{{/* One variant per deployment path, plus one for the no-choice state, and
+		     exactly one unclassed variant on a site that declares no paths — so a
+		     repo not using the gate emits byte-identical markup to before.
+		     Hiding all but the active one is CSS's job; see the .pathnav rules in
+		     custom-header.html. */}}
+		{{- $variants := slice (dict "key" "" "class" "") }}
+		{{- with site.Params.deploymentPaths }}
+			{{- $variants = slice (dict "key" "" "class" "pathnav pathnav--any") }}
+			{{- range . }}
+				{{- $variants = $variants | append (dict "key" .key "class" (printf "pathnav pathnav--%s" .key)) }}
+			{{- end }}
 		{{- end }}
-		{{- partial "topbar/func/button.html" (dict
-			"page" .
-			"class" "topbar-button-prev"
-			"href" $href
-			"icon" "chevron-left"
-			"onwidths" $onwidths
-			"onwidthm" $onwidthm
-			"onwidthl" $onwidthl
-			"hint" (printf "%s (%s)" $prevTitle ($startarrow | safeHTML))
-		)}}
+		{{- range $variants }}
+			{{- $prev := "" }}
+			{{- if .key }}
+				{{- $prev = partial "pathnav/step.gotmpl" (dict "page" $page "dir" "prev" "path" .key) }}
+			{{- else }}
+				{{- $prev = partialCached "_relearn/pagePrev.gotmpl" $page $page.Path }}
+			{{- end }}
+			{{- $prevTitle := partial "title.gotmpl" (dict "page" $prev "outputFormat" "html") }}
+			{{- $href := "" }}
+			{{- with (and $prev $prev.Path) }}
+				{{- $href = . }}
+			{{- end }}
+			{{- partial "topbar/func/button.html" (dict
+				"page" $page
+				"class" (trim (printf "topbar-button-prev %s" .class) " ")
+				"href" $href
+				"icon" "chevron-left"
+				"onwidths" $onwidths
+				"onwidthm" $onwidthm
+				"onwidthl" $onwidthl
+				"hint" (printf "%s (%s)" $prevTitle ($startarrow | safeHTML))
+			)}}
+		{{- end }}
 	{{- end }}
 {{- end }}

--- a/layouts/shortcodes/pathonly.html
+++ b/layouts/shortcodes/pathonly.html
@@ -23,7 +23,15 @@
     {{- errorf "%s: pathonly cannot be nested inside %s. The enclosing block already restricts its body to one path, so this is either redundant or unreachable. Move the content out, or use the enclosing block's path." $file .Name }}
   {{- end }}
 {{- end }}
-{{- $body := trim ($page.RenderString (dict "display" "block") .Inner) "\n\r\t " }}
+{{/* Emitted for the page's own markdown pass to render -- deliberately NOT
+     rendered here with RenderString, and this is why the shortcode must be
+     called with the `{{%` delimiters. RenderString runs in its own render
+     context, so headings inside it never join the page's fragment set: an
+     in-page `[link](#heading)` pointing into this block warns at build time
+     ("heading ID not found") and does nothing when a reader clicks it, and the
+     heading is missing from the page's table of contents. Handing the body back
+     to the page is what registers them. */}}
+{{- $body := trim .Inner "\n\r\t " }}
 {{- if not $body }}
   {{- errorf "%s: this pathonly block is empty. Write the content for the %q path, or delete the block -- an empty pathonly is indistinguishable from a gate that is silently hiding the wrong thing." $file $path }}
 {{- end }}
@@ -31,7 +39,16 @@
      in, so there is one path-gating attribute in the codebase rather than two.
      The gating CSS lives in layouts/partials/custom-header.html: it hides every
      .pathonly by default and re-shows only the matching key, so this markup is
-     inert in exactly one direction -- with the CSS missing, everything shows. */}}
+     inert in exactly one direction -- with the CSS missing, everything shows.
+
+     The blank lines around the body are load-bearing, not formatting. A line
+     starting with `<div` opens a CommonMark raw-HTML block that runs to the next
+     blank line, so without them the body's first block is swallowed into it and
+     emitted as literal text -- a leading `## Heading` renders as the characters
+     "## Heading". A blank line closes the block and hands the body back to the
+     markdown renderer, which is also what registers its heading IDs. */}}
 <div class="pathgate pathonly" data-path="{{ $path }}">
+
 {{ $body | safeHTML }}
+
 </div>

--- a/layouts/shortcodes/pathonly.html
+++ b/layouts/shortcodes/pathonly.html
@@ -1,0 +1,37 @@
+{{- $page := .Page }}
+{{- $file := "[virtual file]" }}
+{{- with and $page $page.File $page.File.Filename }}{{ $file = . }}{{ end }}
+{{- $shape := `"deploymentPaths": [{"key": "docker", "title": "Docker Compose"}, {"key": "k8s", "title": "Kubernetes / Helm"}]` }}
+{{- $specs := site.Params.deploymentPaths | default slice }}
+{{- $keys := slice }}
+{{- range $specs }}
+  {{- $keys = $keys | append .key }}
+{{- end }}
+{{- $path := .Get "path" }}
+{{- if not $specs }}
+  {{- errorf "%s: pathonly requires site.Params.deploymentPaths, which is unset or empty. Declare the path vocabulary in scripts/repoConfig.json, e.g. %s — each entry needs a \"key\" (matched by pathonly path=\"…\") and a \"title\" (the label readers see). There is deliberately no built-in default, so no repo silently inherits another repo's paths." $file $shape }}
+{{- else if not (in $keys $path) }}
+  {{- errorf "%s: pathonly needs path=\"<key>\" where key is one of %v; got %q." $file $keys $path }}
+{{- end }}
+{{/* Nesting inside a pathtab is a hard error rather than a no-op. It is not
+     harmless: the enclosing pathtab already restricts its body to one path, so a
+     pathonly inside it is either redundant (same key) or renders a block that can
+     never appear (different key) -- and the second case looks like working
+     authoring right up until a reader reports missing steps. */}}
+{{- with .Parent }}
+  {{- if in (slice "pathtab" "pathonly") .Name }}
+    {{- errorf "%s: pathonly cannot be nested inside %s. The enclosing block already restricts its body to one path, so this is either redundant or unreachable. Move the content out, or use the enclosing block's path." $file .Name }}
+  {{- end }}
+{{- end }}
+{{- $body := trim ($page.RenderString (dict "display" "block") .Inner) "\n\r\t " }}
+{{- if not $body }}
+  {{- errorf "%s: this pathonly block is empty. Write the content for the %q path, or delete the block -- an empty pathonly is indistinguishable from a gate that is silently hiding the wrong thing." $file $path }}
+{{- end }}
+{{/* Same `.pathgate[data-path]` contract the pathtabs shortcode wraps its panels
+     in, so there is one path-gating attribute in the codebase rather than two.
+     The gating CSS lives in layouts/partials/custom-header.html: it hides every
+     .pathonly by default and re-shows only the matching key, so this markup is
+     inert in exactly one direction -- with the CSS missing, everything shows. */}}
+<div class="pathgate pathonly" data-path="{{ $path }}">
+{{ $body | safeHTML }}
+</div>


### PR DESCRIPTION
Phases 2 and 3 of ai-101 plan 0003. Phase 1 shipped in #72; this finishes the gate.

Participants in the last workshop carried out both the Docker steps and the Kubernetes steps, because both tabs were on the page. #72 gated the tab panels. This gates the four remaining surfaces the same way, so a reader who has chosen a path sees only that path everywhere.

## What this adds

- **Sidebar** — build-time CSS hides each `deploymentPath`-scoped page's `<li>` for every other path. Keyed on `permalink.gotmpl`, not `.RelPermalink`, because `menu.html` sets `data-nav-id` from that partial and it appends `index.html` to any link ending in `/`.
- **Prev/next** — `pathnav/step.gotmpl` walks relearn's own `pageNext`/`pagePrev` chain once per path at build time; the buttons are CSS-gated. Ships with the sidebar rules and never after them: relearn's prev/next honours only `params.hidden`, so hiding a page from the sidebar while leaving it on the linear walk marches the student into a page the sidebar says does not exist.
- **Foreign-path arrival** — a `pathmiss` banner per foreign state on any path-scoped page, since a bookmark or a search result can still land a reader there. The page's own content still renders below it; a blank page with a switcher reads as a broken build, not as a gate.
- **`pathonly` shortcode** — path-specific prose and whole sections outside a tab group. Must be called with `{{%  %}}`: with `{{<  >}}` the shortcode has to render its body via `RenderString`, which runs in a separate render context, so headings inside never join the page's fragment set — an in-page link into the block builds with `WARN heading ID not found` and does nothing when clicked. Found as a real warning on ai-101's `#compose-profiles`.
- **Search** — `relearn.search.adapter.search` is wrapped and filtered against a `uri → deploymentPath` map, covering the results page and the dropdown in one place. The index entry shape is deliberately **not** extended: relearn builds the index once from `site.Home` and feeds it to two engines with independently declared fields (lunr's field list, orama's strict schema), so a new field there is a theme-wide contract change — and `index` is already a name lunr writes into.

## Two deliberate asymmetries

1. **Navigation is not default-deny, body content is.** With no choice stored, the sidebar, prev/next and search all show everything. Default-deny is right for steps, where showing both paths is the original failure; it is wrong for navigation, where it would present a workshop with pages silently missing and no way to tell why.
2. **Every rule only ever hides.** Sidebar `<li>`s and `.topbar-button`s carry the theme's own responsive `display` rules, which a show rule would defeat at small widths. The sidebar rule also carries `:not(.active)` so a foreign-path reader keeps their own "you are here" entry.

## Two authoring combinations are now hard build errors

Both prevented failures that are silent in *both* directions — a CSS selector keyed on the wrong value matches nothing and CSS reports nothing, and `data-nav-id` is the only page identity on the `<li>`, so there is no second attribute to fall back to:

- `deploymentPath` together with `menuPageRef`/`menuUrl`. The crosslink retargets `data-nav-id`, so the generated rule would match nothing and the page would stay visible to every path.
- A scoped page with no permalink. It renders headless with `data-nav-id=""`, so a rule keyed on the empty string would hide every headless sidebar entry rather than that one.

## Verification

- **No regression for the ~65 repos without `deploymentPaths`**, re-proven after Phase 2 *and* Phase 3: `faig-training-workshop` built against this branch is **0 differing files out of 173** (36 pages) once the four per-build nondeterministic tokens are normalised. Note the last-updated stamp needs a weekday-format pattern as well as ISO — an ISO-only normaliser reported a phantom 17-file diff.
- **Sidebar selectors compared byte-for-byte against rendered `data-nav-id` values**, including the `index.html`-append branch, which ai-101's all-leaf content does not exercise on its own (forced with a throwaway `deploymentPath` on a section page).
- **Search proven behaviourally, not structurally**: the real lunr index was rebuilt in Node from `public/searchindex.en.js` and the actual filter run over it. No choice → 13/13 and 8/8 unfiltered. `kubectl` as a Docker reader → 5/8, dropping all three Kubernetes pages. `prerequisites` → 6/8 each way, each path dropping the other's prereq page.
- `:not(.active)` confirmed on all five generated rules, with the page's own `<li>` rendering as `class=active` with the exact `data-nav-id` the rule targets.

Not verified: the visual result in a real browser. Every claim above rests on generated-selector-vs-rendered-markup comparison and the Node search harness, which catch the silent failure mode but not a visual one. This host has no browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
