### PR TITLE
feat: page-scoped deploymentPaths so template clones inherit no path vocabulary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ layouts/
     google_analytics_authorMode.html — ⚠️ DO NOT DELETE — hugoServer_authorMode.sh mv's this into place at dev startup
     silent_cross_site_checkin.html — Background cross-site attendance propagation
     prefill-useremail.html        — Cookie/profile-based form prefill helpers
-    custom-header.html            — 1249 lines: CloudCSEMovie video injection + the ENTIRE deployment-path gate (CSS at :332-510, pre-paint script, search scoping at :746-840)
-    content-header.html           — 101 lines: path chooser, pathmiss banners, .pathswitch, <noscript> fallback
+    custom-header.html            — 1271 lines: CloudCSEMovie video injection + the ENTIRE deployment-path gate (gate CSS at :338-644, pre-paint script at :663-762, search scoping at :791-872)
+    content-header.html           — 108 lines: path chooser, pathmiss banners, .pathswitch, <noscript> fallback
+    pathgate/specs.gotmpl         — Resolves the path vocabulary in effect for ONE page (site param vs. its own front matter); every gate consumer calls this, never site.Params directly
     pathnav/step.gotmpl           — Resolves the next/prev page for ONE deployment path
     topbar/button/prev.html       — Emits one .pathnav prev button per configured path
     topbar/button/next.html       — Emits one .pathnav next button per configured path
@@ -67,7 +68,7 @@ layouts/
     fortihugorunner.html          — Dev harness shortcode (local testing only)
     Xperts24Banner.html           — Xperts 2024 themed banner
     Xperts25Banner.html           — Xperts 2025 themed banner
-    pathtabs.html                 — Deployment-path tab group + locked-path banner; needs site.Params.deploymentPaths
+    pathtabs.html                 — Deployment-path tab group + locked-path banner; needs a vocabulary from pathgate/specs.gotmpl
     pathtab.html                  — One path's content, collected by its parent pathtabs block
     pathonly.html                 — Content shown to ONE path with no tab UI; must be called with {{%…%}}
     colortext.html                — Inline colored text
@@ -159,6 +160,9 @@ docker run --rm -v /path/to/UserRepo:/home/UserRepo:ro hugotester-local build
 ### The deployment-path gate
 
 - **It is pre-paint and CSS-only.** An inline synchronous `<script>` in `<head>` sets `<html data-deployment-path="…">` before `<body>` exists; every gating rule is CSS keyed off that attribute. **Nothing mutates the DOM after load** — that is what prevents the other path's steps flashing on screen before being hidden. Don't "improve" any of it into a `DOMContentLoaded` handler.
+- **Two declaration scopes, resolved in exactly one place: `partials/pathgate/specs.gotmpl`.** `site.Params.deploymentPaths` (repoConfig.json) gates the whole workshop; `deploymentPaths` in a **page's front matter** gates that page's blocks and nothing else. Every consumer — `content-header.html`, `pathtabs`, `pathtab`, `pathonly` — calls the partial; none reads `site.Params.deploymentPaths` for content gating. The page form exists because UserRepo is cloned to start every new workshop, so a site param there is inherited by every new repo; front matter travels with the demo page and leaves when it is deleted.
+- **Declaring both is a hard `errorf`, not a precedence rule.** There is one stored choice per reader per site (`<absBaseUri>/deployment-path`), so a page-local key lands in the same slot the site-wide gate reads back — every site-wide gated page would then fall through to default-deny and show nothing, with no error, because default-deny is also correct before a first choice.
+- **The three site-wide behaviours stay bound to the site param alone.** In `custom-header.html` the sidebar loop, the prev/next CSS and the search `SCOPED` list all key off `$sitePaths` (the raw site param), never the resolved per-page vocabulary — filtering the whole site's navigation on one page's private list would hide pages the reader can legitimately reach. Same reason `deploymentPath` (singular) still requires the site param.
 - **Content is default-deny; navigation is deliberately NOT.** A `pathonly`/`pathtab` block with no stored choice shows nothing. But with no choice the sidebar, prev/next and search show **everything** — a table of contents with pages silently missing reads as a broken build, not as a gate, and the reader has no way to tell which it is.
 - **Every navigation rule only ever hides, via `:not(...)` — never force `display` back on.** Sidebar `<li>`s and `.topbar-button`s carry the theme's own responsive `display` rules; re-asserting `display` from the gate overrides them and breaks the mobile layout.
 - **`:not(.active)` on the sidebar hide rule is load-bearing.** It keeps a foreign-path reader's *own* "you are here" entry, so the sidebar still highlights something. It leaks nothing — the `pathmiss` banner already names the mismatch, and an entry for the page on screen reveals no steps the reader can't see. `active` is the first class on the `<li>` (`menu.html:149,184,309,345`).
@@ -192,7 +196,7 @@ docker run --rm -v /path/to/UserRepo:/home/UserRepo:ro hugotester-local build
 }
 ```
 
-- **`deploymentPaths`** — required by `pathtabs`/`pathtab`/`pathonly` and by any page carrying a `deploymentPath` front-matter param; optional for every other site. **This is the single source of a repo's path vocabulary** — a consuming repo's tooling should derive its path list from here rather than hardcoding it. `key` is what `pathtab path="…"` matches; `title` is the tab label. **Order is load-bearing:** the first entry is the tab Hugo marks active server-side, so it is both the first-time default and the banner text with JS off. **Renaming a `title` silently resets every returning reader** — relearn keys the stored selection on `anchorize(title)` (`themes/hugo-theme-relearn/layouts/partials/shortcodes/tabs.html:42`), so old selections stop matching with no build error. Renaming a `key` is the loud kind of change: every `pathtab path=` must follow or the build fails.
+- **`deploymentPaths`** — gates the whole workshop. Required by any page carrying a `deploymentPath` front-matter param, and by `pathtabs`/`pathtab`/`pathonly` unless the page declares its own `deploymentPaths` in front matter (page-scoped alternative; the two are mutually exclusive — see the gate section). **This is the single source of a repo's site-wide path vocabulary** — a consuming repo's tooling should derive its path list from here rather than hardcoding it. `key` is what `pathtab path="…"` matches; `title` is the tab label. **Order is load-bearing:** the first entry is the tab Hugo marks active server-side, so it is both the first-time default and the banner text with JS off. **Renaming a `title` silently resets every returning reader** — relearn keys the stored selection on `anchorize(title)` (`themes/hugo-theme-relearn/layouts/partials/shortcodes/tabs.html:42`), so old selections stop matching with no build error. Renaming a `key` is the loud kind of change: every `pathtab path=` must follow or the build fails.
 - **`errorignore`** — list of regexes, matched unanchored with `findRE` against the offending URL in `themes/hugo-theme-relearn/layouts/partials/_relearn/urlErrorReport.gotmpl:5,15-19`. Site-wide across the link/image/include/openapi checks, so prefer an anchored pattern over `\.pdf$`.
 - Both params are emitted by `scripts/templates/hugo.jinja` only when present and non-empty, so omitting them changes no existing site. Both are declared in `scripts/repoConfig.schema.json`; `deploymentPaths` entries are `additionalProperties: false` with `key` and `title` required.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Direct src override:
 ### pathtabs / pathtab
 Parallel steps for two or more mutually exclusive deployment paths, of which a reader follows exactly one. Only the reader's chosen path is shown — in the page body, the sidebar, the next/previous buttons, and search.
 
-Requires `deploymentPaths` in the workshop's `scripts/repoConfig.json`. There is no default vocabulary: a repo that does not declare paths cannot use these shortcodes, and no repo inherits another repo's paths.
+Requires a `deploymentPaths` declaration — either the site param in the workshop's `scripts/repoConfig.json` (gates the whole workshop: blocks, sidebar, prev/next, search, and a switcher on every page) or the same list in one page's front matter (gates that page's blocks only, and nothing else in the site). There is no default vocabulary: a repo that does not declare paths cannot use these shortcodes, and no repo inherits another repo's paths. Declaring both at once is a build error.
 
 Usage:
 ```
@@ -117,7 +117,7 @@ Parameters:
 
 Note the delimiters: `{{< pathtabs >}}` (angle) for the wrapper, `{{% pathtab %}}` (percent) for each body, so the body is rendered as markdown.
 
-Build fails when: `deploymentPaths` is unset; a block omits any configured path; a block defines the same path twice; a body is empty; `path=` names an unknown key; a `pathtab` sits outside a `pathtabs`. Each failure is a deliberate error rather than a warning, because the alternative is a gate that silently shows the wrong path's steps.
+Build fails when: no `deploymentPaths` is in effect for the page; a page declares `deploymentPaths` in front matter while the site param also exists; a block omits any configured path; a block defines the same path twice; a body is empty; `path=` names an unknown key; a `pathtab` sits outside a `pathtabs`. Each failure is a deliberate error rather than a warning, because the alternative is a gate that silently shows the wrong path's steps.
 
 ### pathonly
 One path's content with no tab UI — prose, a warning, or a whole section that has no counterpart on the other paths. Same gating mechanism as `pathtab` (both emit `.pathgate[data-path]`), so there is one gate, not two.
@@ -133,7 +133,7 @@ Parameters:
 
 **Must be called with the percent form.** With `{{< pathonly >}}`, `RenderString` gives the body its own render context, so headings inside never join the page's fragment set and every in-page anchor to them breaks silently. Blank lines above and below the tags are also load-bearing: a line beginning `<div` opens a CommonMark type-6 raw-HTML block that runs to the next blank line, and without them the body is never rendered as markdown.
 
-Build fails when: `deploymentPaths` is unset; `path=` names an unknown key; the block is nested inside `pathtabs`/`pathonly`; the body is empty.
+Build fails when: no `deploymentPaths` is in effect for the page; a page declares `deploymentPaths` in front matter while the site param also exists; `path=` names an unknown key; the block is nested inside `pathtabs`/`pathonly`; the body is empty.
 
 ### colortext
 Inline colored text.
@@ -163,9 +163,9 @@ A reader picks a path once — Docker Compose vs Kubernetes, for example — and
 
 If the content is a *sentence* rather than a block, none of these fit — reword it to be path-neutral, or name both mechanisms. A block-level shortcode cannot wrap half a sentence, and gating a whole paragraph to hide one clause hides information the other path needed.
 
-Usage (two parts — the site param is a prerequisite):
+Usage (two parts — a `deploymentPaths` declaration is a prerequisite):
 
-1. Declare the path vocabulary in `scripts/repoConfig.json`:
+1. Declare the path vocabulary. Site-wide, in `scripts/repoConfig.json`:
 ```json
 {
   "deploymentPaths": [
@@ -174,6 +174,15 @@ Usage (two parts — the site param is a prerequisite):
   ]
 }
 ```
+   …or, for a single self-contained page, in that page's front matter:
+```yaml
+deploymentPaths:
+  - key: docker
+    title: Docker Compose
+  - key: k8s
+    title: Kubernetes / Helm
+```
+   The site param gates the whole workshop — blocks, sidebar, prev/next, search, switcher on every page. The front-matter form gates that page's own blocks and touches none of the site-wide behaviour, which is what a live example inside a guide needs. `layouts/partials/pathgate/specs.gotmpl` resolves the two and hard-errors if both are present, because one stored choice cannot serve two vocabularies: the page would write its key into the slot every site-wide page reads back, and those pages would fall through to default-deny and show nothing, with no error anywhere.
 
 2. Wrap one `pathtab` per configured path in the content:
 ```
@@ -199,7 +208,10 @@ Parameters (`pathtab`):
 - `path`: Required. Must match a `key` in `deploymentPaths`, and the shortcode must be nested inside a `pathtabs` block. An unknown key or an unnested `pathtab` is a build `errorf`.
 
 Site params:
-- `deploymentPaths`: Required list of `{key, title}` objects. There is no built-in default — if the param is missing the build fails with an `errorf` naming it. A shared shortcode must not carry one workshop's vocabulary.
+- `deploymentPaths`: Required list of `{key, title}` objects, unless the page declares its own (below). There is no built-in default — if neither is present the build fails with an `errorf` naming it. A shared shortcode must not carry one workshop's vocabulary.
+
+Page params:
+- `deploymentPaths`: The same list in a page's front matter, for a page that gates itself and nothing else. Mutually exclusive with the site param. `deploymentPath` (singular, scoping a whole page to one path) still requires the **site** param, because what it gates — sidebar, prev/next, search — is site-wide by definition.
 
 Behavior:
 - Every `pathtabs` block must define every configured path exactly once. A missing path or a duplicate path is a build `errorf`, so a reader on the missing path can never silently be shown the other path's steps. An empty `pathtab` body is also an `errorf`.
@@ -261,7 +273,7 @@ Search results are filtered to the reader's path, because a search hit is the si
 - Switching paths clears the autocomplete cache. `auto-complete.js` stores results on the `#R-search-by` element keyed by raw input value, and short-circuits any term whose shorter prefix cached zero results — so one term that legitimately found nothing on the old path would otherwise poison itself and every extension of it. If results are already on screen, the search re-runs.
 
 ### Repos that declare no paths
-`deploymentPaths` is absent from nearly every workshop repo, and all of the above is inert without it: no gate script, no gate CSS, one unclassed prev/next button each, and no `pathnav` classes. Output is byte-identical to a build without the feature.
+`deploymentPaths` is absent from nearly every workshop repo, and all of the above is inert without it: no gate script, no gate CSS, one unclassed prev/next button each, and no `pathnav` classes. Output is byte-identical to a build without the feature. A page-level declaration narrows this to the declaring page: every other page in that site is still byte-identical to a build without the feature, and the sidebar, prev/next and search gating are not emitted at all.
 
 ## Theme variants
 
@@ -311,9 +323,9 @@ The `CloudCSEMovie` variant replaces the static header image with a looping MP4 
 - `quizUrl`: Base URL for `quizframe`.
 - `videoHeaderSrc`: Path to the sidebar header background MP4 (`CloudCSEMovie` theme only).
 - `videoHeaderInterval`: Seconds between video play cycles (`CloudCSEMovie` theme only, default `60`).
-- `deploymentPaths`: Optional list of `{ "key": …, "title": … }` declaring a workshop's mutually exclusive deployment paths. Required by `pathtabs`/`pathtab`/`pathonly` and by any page carrying a `deploymentPath` front-matter param; omitting it leaves every one of those features inert. `key` must start with a letter and contain only letters, digits, hyphens and underscores, because it is interpolated into CSS class names as well as attribute values. **Order is load-bearing** — the first entry is the JavaScript-off default and the server-side active tab. **Renaming a `title` silently resets every returning reader's stored choice** (the selection is keyed on the title text); renaming a `key` fails the build instead, which is the safer failure.
+- `deploymentPaths`: Optional list of `{ "key": …, "title": … }` declaring a workshop's mutually exclusive deployment paths. Required by `pathtabs`/`pathtab`/`pathonly` (or the same list in the page's own front matter, which gates that page alone and cannot coexist with this param) and by any page carrying a `deploymentPath` front-matter param, which needs this site-level form; omitting it leaves every one of those features inert. `key` must start with a letter and contain only letters, digits, hyphens and underscores, because it is interpolated into CSS class names as well as attribute values. **Order is load-bearing** — the first entry is the JavaScript-off default and the server-side active tab. **Renaming a `title` silently resets every returning reader's stored choice** (the selection is keyed on the title text); renaming a `key` fails the build instead, which is the safer failure.
 - `errorignore`: Optional list of regexes suppressing relearn's URL error report for targets it cannot resolve as pages (e.g. a PDF referenced from `menu.shortcuts`).
-- `deploymentPaths`: List of `{key, title}` objects defining the path vocabulary for `pathtabs`, `pathonly` and the `deploymentPath` page param. Required by all three — the build fails if it is absent. Declaring it is also what switches the whole gate on; a repo without it builds byte-identically to one built before the feature existed. Keys are used as CSS class suffixes as well as attribute values, so a key must start with a letter and contain only letters, digits, hyphens and underscores.
+- `deploymentPaths`: List of `{key, title}` objects defining the path vocabulary for `pathtabs`, `pathonly` and the `deploymentPath` page param. Required by all three — the build fails if neither this nor a page-level `deploymentPaths` is present (`deploymentPath` needs this site-level form specifically). Declaring it is also what switches the whole gate on; a repo without it builds byte-identically to one built before the feature existed. Keys are used as CSS class suffixes as well as attribute values, so a key must start with a letter and contain only letters, digits, hyphens and underscores.
 - `errorignore`: List of regex strings. Relearn matches each one against the offending URL in `themes/hugo-theme-relearn/layouts/partials/_relearn/urlErrorReport.gotmpl:5` and suppresses the link/image/include/openapi warning or error when any matches.
 
 ## Cookie overview

--- a/layouts/partials/content-header.html
+++ b/layouts/partials/content-header.html
@@ -3,9 +3,14 @@
      cannot proceed without choosing and must be offered the chooser. */}}
 {{- $hasPathtabs := or (.HasShortcode "pathtabs") (.HasShortcode "pathonly") }}
 {{- $ownPath := .Params.deploymentPath | default "" }}
+{{/* Site param or this page's own front matter -- see partials/pathgate/specs.gotmpl.
+     Under a page-local declaration everything below is emitted for that one page,
+     which is exactly the scope of the gating it drives. */}}
+{{- $paths := partial "pathgate/specs.gotmpl" $page }}
+{{- $siteWide := gt (len (site.Params.deploymentPaths | default slice)) 0 }}
 {{- $titles := slice }}
-{{- range .Site.Params.deploymentPaths }}{{ $titles = $titles | append .title }}{{ end }}
-{{- with .Site.Params.deploymentPaths }}
+{{- range $paths }}{{ $titles = $titles | append .title }}{{ end }}
+{{- with $paths }}
 {{/* The no-choice chooser and the no-JavaScript warning live here rather than in
      the pathtabs shortcode. A shortcode writes into .Content, which relearn
      plainifies into <meta name="description"> (partials/meta.html:44) and indexes
@@ -28,7 +33,7 @@
 {{- if not $ownPath }}
 <div class="pathgate-chooser" role="group" aria-label="Choose your deployment path">
   <div class="pathgate-chooser__lead">Choose your deployment path</div>
-  <div class="pathgate-chooser__hint">This page's steps are hidden until you pick one. Every other lab page then follows the same choice, and you can switch at any time from the header.</div>
+  <div class="pathgate-chooser__hint">This page's steps are hidden until you pick one. {{ if $siteWide }}Every other lab page then follows the same choice, and you can switch at any time from the header.{{ else }}The choice affects this page only, and you can switch at any time.{{ end }}</div>
   <div class="pathgate-chooser__actions">
     {{- range . }}
     <button type="button" class="pathgate-chooser__btn" data-choose-path="{{ .key }}">{{ .title }}</button>
@@ -46,17 +51,17 @@
 {{- with $ownPath }}
   {{- $own := . }}
   {{- $ownTitle := "" }}
-  {{- range $.Site.Params.deploymentPaths }}{{ if eq .key $own }}{{ $ownTitle = .title }}{{ end }}{{ end }}
+  {{- range $paths }}{{ if eq .key $own }}{{ $ownTitle = .title }}{{ end }}{{ end }}
 <div class="pathmiss" data-for-path="" role="note">
   <strong>This page is part of the {{ $ownTitle }} path.</strong>
   You have not chosen a path yet. Pick one and every page follows it, including the sidebar and the next/previous buttons.
   <div class="pathmiss__actions">
-    {{- range $.Site.Params.deploymentPaths }}
+    {{- range $paths }}
     <button type="button" class="pathgate-chooser__btn" data-choose-path="{{ .key }}">{{ .title }}</button>
     {{- end }}
   </div>
 </div>
-  {{- range $.Site.Params.deploymentPaths }}
+  {{- range $paths }}
     {{- if ne .key $own }}
 <div class="pathmiss" data-for-path="{{ .key }}" role="note">
   <strong>This page is part of the {{ $ownTitle }} path, and you are following {{ .title }}.</strong>
@@ -68,11 +73,13 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{/* The switcher goes on every page, not only pages that use pathtabs, because
-     the choice is site-wide: a reader who picks the wrong path otherwise has to
-     find a page that happens to contain a pathtabs block before they can change
-     it. Hidden by CSS until a path is actually chosen -- see the gate block in
-     custom-header.html for the state machine. */}}
+{{/* Under a site-level declaration the switcher goes on every page, not only the
+     pages that use pathtabs, because the choice is site-wide: a reader who picks
+     the wrong path otherwise has to find a page that happens to contain a
+     pathtabs block before they can change it. Under a page-level declaration
+     this partial only reaches this branch on the declaring page, which is the
+     only page the choice affects. Hidden by CSS until a path is actually chosen
+     -- see the gate block in custom-header.html for the state machine. */}}
 <div class="pathswitch">
   <span class="pathswitch__label" aria-live="polite"><i class="fa-fw fas fa-lock"></i>
     {{- range . }}<span class="pathswitch__value" data-path="{{ .key }}">{{ .title }}</span>{{ end }}

--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -316,9 +316,16 @@
 </style>
 
 {{- $page := . }}
-{{- with .Site.Params.deploymentPaths }}
-{{/* Deployment-path gate. Everything below is emitted only for a site that
-     declares deploymentPaths, so it is zero bytes for every repo that does not
+{{/* Site-declared paths, kept separate from the page's effective vocabulary
+     below: the three site-wide behaviours (sidebar, prev/next, search) must only
+     ever follow a site-level declaration. A page that declares deploymentPaths
+     in its own front matter gates its own blocks and nothing else -- see
+     partials/pathgate/specs.gotmpl for why that form exists. */}}
+{{- $sitePaths := site.Params.deploymentPaths | default slice }}
+{{- $noPages := slice }}
+{{- with partial "pathgate/specs.gotmpl" $page }}
+{{/* Deployment-path gate. Everything below is emitted only for a page with a
+     path vocabulary in effect, so it is zero bytes for every repo that does not
      use the pathtabs shortcode.
 
      Why it lives here rather than in the shortcode: the CSS has to be in <head>
@@ -447,8 +454,12 @@ html[data-deployment-path="{{ .key }}"] .pathmiss[data-for-path="{{ .key }}"] {
    Nothing is hidden while data-deployment-path is "" -- a reader who has not
    chosen yet gets the full table of contents. Default-deny is right for steps,
    where showing both paths is the original failure; it is wrong for navigation,
-   where it would present a workshop with pages missing and no way to tell why. */
-{{- range $p := site.Pages }}
+   where it would present a workshop with pages missing and no way to tell why.
+
+   Walked only when the *site* declares the vocabulary. A page-local declaration
+   gates that page's own blocks, so hiding another page's sidebar entry on the
+   strength of it would key a site-wide rule on one page's private list. */
+{{- range $p := (cond (gt (len $sitePaths) 0) site.Pages $noPages) }}
   {{- with $p.Params.deploymentPath }}
     {{- $own := . }}
     {{- if not (in $keys $own) }}
@@ -498,15 +509,22 @@ html[data-deployment-path="{{ .key }}"] #R-sidebar li[data-nav-id="{{ $navid | s
    `pathnav--any` one for the no-choice state; all but the matching one are
    hidden. Hiding a page from the sidebar while leaving it on the linear walk
    would march the reader into a page the sidebar says does not exist, which is
-   why this ships with the sidebar rules above and never after them. */
-{{- range . }}
+   why this ships with the sidebar rules above and never after them.
+
+   Site-declared paths only, for the same reason as the sidebar -- and because
+   the buttons themselves only carry the `pathnav` classes when the site declares
+   the vocabulary (topbar/button/next.html), so under a page-local declaration
+   these rules would be dead CSS. */
+{{- range $sitePaths }}
 html[data-deployment-path="{{ .key }}"] .topbar-button.pathnav:not(.pathnav--{{ .key }}) {
   display: none;
 }
 {{- end }}
+{{- if $sitePaths }}
 html[data-deployment-path=""] .topbar-button.pathnav:not(.pathnav--any) {
   display: none;
 }
+{{- end }}
 
 .pathswitch {
   align-items: center;
@@ -759,9 +777,13 @@ html[data-deployment-path=""] .topbar-button.pathnav:not(.pathnav--any) {
      contract change. `uri` is already a unique per-page identity that reaches
      the results, and one small side map keyed on it needs neither engine to
      agree to anything. (lunr also writes `page.index` onto every entry, so
-     `index` is a field name that must never be added.) */}}
+     `index` is a field name that must never be added.)
+
+     Site-declared paths only: a page-local vocabulary gates that page's blocks,
+     and filtering the whole site's search results on one page's private list
+     would hide pages a reader can still legitimately reach. */}}
 {{- $scoped := slice }}
-{{- range $p := site.Pages }}
+{{- range $p := (cond (gt (len $sitePaths) 0) site.Pages $noPages) }}
   {{- with $p.Params.deploymentPath }}
     {{- $scoped = $scoped | append (dict "uri" (partial "permalink.gotmpl" (dict "to" $p)) "path" .) }}
   {{- end }}

--- a/layouts/partials/pathgate/specs.gotmpl
+++ b/layouts/partials/pathgate/specs.gotmpl
@@ -1,0 +1,42 @@
+{{- /*
+  Return the deployment-path vocabulary in effect for one page.
+
+  Two places can declare it, for two different jobs:
+
+    site.Params.deploymentPaths  (scripts/repoConfig.json)
+      The whole workshop is gated. Content blocks, the sidebar, prev/next and
+      search all follow the reader's one choice, and the switcher is on every
+      page. This is what a real two-path workshop wants.
+
+    deploymentPaths in a page's front matter
+      Only that page gates anything. No sidebar entry is hidden, no prev/next
+      button is filtered, search is untouched, and the switcher appears on that
+      page alone. This is what a single self-contained page wants -- a live
+      example inside a guide, or one lab page that happens to fork.
+
+  Why the page-level form exists at all: UserRepo is cloned to start every new
+  workshop, so anything in its scripts/repoConfig.json is inherited by every new
+  repo. A site-level declaration there would hand every new workshop a path
+  vocabulary it never asked for, and the switcher on every one of its pages.
+  Front matter travels with the one page that demonstrates the feature and
+  disappears when that page is deleted.
+
+  Declaring both is a hard error rather than a precedence rule. There is exactly
+  one stored choice per reader per site (`<absBaseUri>/deployment-path`), so a
+  page-local key would be written into the same slot the site-wide gate reads
+  back. Every site-wide gated page would then fail to match it and fall through
+  to default-deny, showing the reader nothing at all -- with no error anywhere,
+  because default-deny is also the correct behaviour before a first choice.
+
+  Argument: the page.
+  Returns the spec list, or an empty slice when neither place declares one.
+*/ -}}
+{{- $page := . }}
+{{- $site := site.Params.deploymentPaths | default slice }}
+{{- $own := $page.Params.deploymentPaths | default slice }}
+{{- if and $own $site }}
+  {{- $file := "[virtual file]" }}
+  {{- with and $page $page.File $page.File.Filename }}{{ $file = . }}{{ end }}
+  {{- errorf "%s: this page declares deploymentPaths in its front matter, but the site already declares them in scripts/repoConfig.json. Use one or the other: front matter gates this page only, the site param gates the whole workshop. Both at once puts two vocabularies behind one stored choice, and the site-wide pages silently show nothing." $file }}
+{{- end }}
+{{- return (cond (gt (len $own) 0) $own $site) }}

--- a/layouts/shortcodes/pathonly.html
+++ b/layouts/shortcodes/pathonly.html
@@ -2,14 +2,14 @@
 {{- $file := "[virtual file]" }}
 {{- with and $page $page.File $page.File.Filename }}{{ $file = . }}{{ end }}
 {{- $shape := `"deploymentPaths": [{"key": "docker", "title": "Docker Compose"}, {"key": "k8s", "title": "Kubernetes / Helm"}]` }}
-{{- $specs := site.Params.deploymentPaths | default slice }}
+{{- $specs := partial "pathgate/specs.gotmpl" $page }}
 {{- $keys := slice }}
 {{- range $specs }}
   {{- $keys = $keys | append .key }}
 {{- end }}
 {{- $path := .Get "path" }}
 {{- if not $specs }}
-  {{- errorf "%s: pathonly requires site.Params.deploymentPaths, which is unset or empty. Declare the path vocabulary in scripts/repoConfig.json, e.g. %s — each entry needs a \"key\" (matched by pathonly path=\"…\") and a \"title\" (the label readers see). There is deliberately no built-in default, so no repo silently inherits another repo's paths." $file $shape }}
+  {{- errorf "%s: pathonly needs a deploymentPaths vocabulary and none is in effect for this page. Declare the path vocabulary either in scripts/repoConfig.json as a site param, e.g. %s, or -- for a single self-contained page -- as deploymentPaths in this page's own front matter. Each entry needs a \"key\" (matched by pathonly path=\"…\") and a \"title\" (the label readers see). There is deliberately no built-in default, so no repo silently inherits another repo's paths." $file $shape }}
 {{- else if not (in $keys $path) }}
   {{- errorf "%s: pathonly needs path=\"<key>\" where key is one of %v; got %q." $file $keys $path }}
 {{- end }}

--- a/layouts/shortcodes/pathtab.html
+++ b/layouts/shortcodes/pathtab.html
@@ -3,14 +3,14 @@
 {{- $file := "[virtual file]" }}
 {{- with and $page $page.File $page.File.Filename }}{{ $file = . }}{{ end }}
 {{- $shape := `"deploymentPaths": [{"key": "docker", "title": "Docker Compose"}, {"key": "k8s", "title": "Kubernetes / Helm"}]` }}
-{{- $specs := site.Params.deploymentPaths | default slice }}
+{{- $specs := partial "pathgate/specs.gotmpl" $page }}
 {{- $keys := slice }}
 {{- range $specs }}
   {{- $keys = $keys | append .key }}
 {{- end }}
 {{- $path := .Get "path" }}
 {{- if not $specs }}
-  {{- errorf "%s: pathtab requires site.Params.deploymentPaths, which is unset or empty. Declare the path vocabulary in scripts/repoConfig.json, e.g. %s — each entry needs a \"key\" (matched by pathtab path=\"…\") and a \"title\" (the tab label). There is deliberately no built-in default, so no repo silently inherits another repo's paths." $file $shape }}
+  {{- errorf "%s: pathtab needs a deploymentPaths vocabulary and none is in effect for this page. Declare the path vocabulary either in scripts/repoConfig.json as a site param, e.g. %s, or -- for a single self-contained page -- as deploymentPaths in this page's own front matter. Each entry needs a \"key\" (matched by pathtab path=\"…\") and a \"title\" (the label readers see). There is deliberately no built-in default, so no repo silently inherits another repo's paths." $file $shape }}
 {{- else if not (in $keys $path) }}
   {{- errorf "%s: pathtab needs path=\"<key>\" where key is one of %v; got %q." $file $keys $path }}
 {{- end }}

--- a/layouts/shortcodes/pathtabs.html
+++ b/layouts/shortcodes/pathtabs.html
@@ -6,9 +6,10 @@
 {{- $groupid := .Get "groupid" | default "deploy-path" }}
 {{- $label := .Get "title" | default "Your path" }}
 {{- $shape := `"deploymentPaths": [{"key": "docker", "title": "Docker Compose"}, {"key": "k8s", "title": "Kubernetes / Helm"}]` }}
-{{- $specs := site.Params.deploymentPaths | default slice }}
+{{- $specs := partial "pathgate/specs.gotmpl" $page }}
+{{- $siteWide := gt (len (site.Params.deploymentPaths | default slice)) 0 }}
 {{- if not $specs }}
-  {{- errorf "%s: pathtabs requires site.Params.deploymentPaths, which is unset or empty. Declare the path vocabulary in scripts/repoConfig.json, e.g. %s — each entry needs a \"key\" (matched by pathtab path=\"…\") and a \"title\" (the tab label). There is deliberately no built-in default, so no repo silently inherits another repo's paths." $file $shape }}
+  {{- errorf "%s: pathtabs needs a deploymentPaths vocabulary and none is in effect for this page. Declare the path vocabulary either in scripts/repoConfig.json as a site param, e.g. %s, or -- for a single self-contained page -- as deploymentPaths in this page's own front matter. Each entry needs a \"key\" (matched by pathtab path=\"…\") and a \"title\" (the label readers see). There is deliberately no built-in default, so no repo silently inherits another repo's paths." $file $shape }}
 {{- end }}
 {{- $keys := slice }}
 {{- range $specs }}
@@ -65,7 +66,7 @@
     <div class="pathlock__head"><i class="fa-fw fas fa-lock"></i> {{ $label }}:&nbsp;
       {{- range $specs }}<span class="pathlock__value" data-path="{{ .key }}">{{ .title }}</span>{{ end }}
     </div>
-    <div class="pathlock__hint">Locked in — every lab page follows this choice.</div>
+    <div class="pathlock__hint">Locked in — {{ if $siteWide }}every lab page follows this choice{{ else }}this page follows this choice{{ end }}.</div>
   </div>
   {{ partial "shortcodes/tabs.html" (dict
     "page"    $page


### PR DESCRIPTION
## Why

UserRepo is the template cloned to start every new workshop. Any `deploymentPaths` in its `scripts/repoConfig.json` is therefore inherited by every new repo — two paths named "(example)" and a padlock line on every page, in a workshop that never asked for the feature.

The site param is already the on-switch (the gate is zero bytes without it), so "make it optional" was not the fix. The inheritance vector was the *declaration location*.

## What

A page can now declare `deploymentPaths` in its own front matter. That gates **that page's blocks only** — no sidebar entry hidden, no prev/next filtered, search untouched, switcher on that page alone.

- New `layouts/partials/pathgate/specs.gotmpl` is the single resolution point. `content-header.html`, `pathtabs`, `pathtab` and `pathonly` all call it; none reads `site.Params.deploymentPaths` for content gating any more.
- **Declaring both scopes is a hard `errorf`**, not a precedence rule. There is one stored choice per reader per site (`<absBaseUri>/deployment-path`), so a page-local key would land in the slot every site-wide page reads back — those pages would fall through to default-deny and show nothing, with no error, because default-deny is also correct before a first choice.
- The three site-wide behaviours (sidebar hiding, prev/next filtering, search scoping) stay keyed on the raw site param. Filtering site-wide navigation on one page's private vocabulary would hide pages the reader can legitimately reach. `deploymentPath` (singular) therefore still requires the site param.
- Chooser hint, lock banner and the "no vocabulary" error text are mode-aware.

## Verification

- Existing consumer ai-101 builds **byte-identical** to stock, modulo build nondeterminism established by building the baseline twice (asset cache-busters, `R-image-*`, anonymous `data-tab-group` hashes, last-updated stamp).
- Page-local mode: build exit 0, demo page emits `pathgate-chooser`, `pathlock`, `pathgate data-path=docker`, `pathgate data-path=k8s`, `pathgate pathonly data-path=k8s`, `pathswitch`; a sibling page in the same site emits none of `pathgate`/`pathlock`/`pathswitch`/`pathnav`/`data-deployment-path`.
- Both new hard errors fire with their intended messages.

Companion UserRepo PR drops the site param and moves the example into the guide page's front matter — merge this first, the prod image has to carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)