### PR TITLE
fix: restore the public/ ignore pattern split by a missing newline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__/
 VERSION
 node_modules/
 tmp/
-public/.claude/settings.local.json
+public/
+.claude/settings.local.json


### PR DESCRIPTION
`.gitignore` line 15 was `public/.claude/settings.local.json` — one pattern that matches nothing real. PR #79 appended `.claude/settings.local.json` to a file whose last line (`public/`) had no trailing newline.

Effect: neither `public/` nor the settings override was ignored. A local Hugo build in this checkout produced ~400 untracked files under `public/`, one `git add -A` from landing the built site on `main`.

Split back into two lines. `git check-ignore -v` now resolves both. No image rebuild — `.gitignore` is on `paths-ignore` as of #80.